### PR TITLE
Fix sign error in stress predictor

### DIFF
--- a/mace_jax/tools/predictors.py
+++ b/mace_jax/tools/predictors.py
@@ -62,8 +62,8 @@ def predict_energy_forces_stress(
         jnp.einsum("iu,iv->iuv", minus_forces, graph.nodes.positions),
         nel=graph.n_node,
     )  # [n_graphs, 3, 3]
-    viriel = stress_cell + stress_forces  # NOTE: sign suggested by Ilyes Batatia
-    stress = -1.0 / det * viriel  # NOTE: sign suggested by Ilyes Batatia
+    virial = stress_cell + stress_forces
+    stress = virial / det
 
     # TODO(mario): fix this
     # make it traceless? because it seems that our formula is not valid for the trace


### PR DESCRIPTION
I believe there is a sign error in the current stress prediction implementation. I have verified this by implementing the stress calculation based on the gradient with respect to a symmetric strain tensor (see `predict_energy_forces_stress_eps`) as is commonly done in other code:

```python
# /// script
# requires-python = ">=3.12"
# dependencies = ["mace-jax", "dm-haiku", "e3nn-jax"]
# [tool.uv.sources]
# mace-jax = { path = "." }
# ///

from collections import namedtuple
import jax
import jax.numpy as jnp
import jraph
import e3nn_jax as e3nn
import haiku as hk
from mace_jax.modules import MACE
from mace_jax.tools.predictors import predict_energy_forces_stress
from mace_jax import tools

# predict stress using displacement tensor eps
# e.g.:
# https://github.com/ACEsuit/mace/blob/d39cc6b5f0f416dbc5eb3462f67544592130076e/mace/modules/utils.py#L50-L63
# https://github.com/mir-group/nequip/blob/eb820b15a6b982e4f14dd77254327e89182333ae/nequip/nn/grad_output.py#L317-L336
def predict_energy_forces_stress_eps(model, graph: jraph.GraphsTuple):
    def total_energy_fn(positions_eps):
        positions, eps = positions_eps
        eps_sym = (eps + jnp.swapaxes(eps, 1, 2)) / 2
        eps_sym_per_node = jnp.repeat(
            eps_sym,
            graph.n_node,
            axis=0,
            total_repeat_length=graph.nodes.positions.shape[0],
        )
        
        # apply displacement eps to positions and cell
        positions = positions + jnp.einsum("ik,ikj->ij", positions, eps_sym_per_node)
        cell = graph.globals.cell + jnp.einsum("bij,bjk->bik", graph.globals.cell, eps_sym)
        
        vectors = tools.get_edge_relative_vectors(
            positions=positions,
            senders=graph.senders,
            receivers=graph.receivers,
            shifts=graph.edges.shifts,
            cell=cell,
            n_edge=graph.n_edge,
        )
        
        node_energies = model(vectors, graph.nodes.species, graph.senders, graph.receivers)
        return jnp.sum(node_energies), node_energies

    eps = jnp.zeros_like(graph.globals.cell)
    
    (minus_forces, virial), node_energies = jax.grad(
        total_energy_fn, has_aux=True
    )((graph.nodes.positions, eps))

    graph_energies = e3nn.scatter_sum(node_energies, nel=graph.n_node)
    det = jnp.abs(jnp.linalg.det(graph.globals.cell))[:, None, None]
    det = jnp.where(det > 0.0, det, 1.0)
    stress = virial / det

    return {
        "energy": graph_energies,
        "forces": -minus_forces,
        "stress": stress,
    }


def bessel_basis(length, max_length, number: int = 8):
    return e3nn.bessel(length, number, max_length)


def soft_envelope(length, max_length):
    return e3nn.soft_envelope(length, max_length)


@hk.without_apply_rng
@hk.transform
def energy_model(vectors, species, senders, receivers):
    return jnp.sum(MACE(
        output_irreps="1x0e",
        r_max=5.0,
        num_interactions=3,
        hidden_irreps=e3nn.Irreps("32x0e"),
        readout_mlp_irreps=e3nn.Irreps("16x0e"),
        avg_num_neighbors=8,
        num_species=2,
        max_ell=2,
        correlation=3,
        gate=jax.nn.silu,
        radial_basis=lambda length, max_length: bessel_basis(length, max_length, 8),
        radial_envelope=lambda length, max_length: soft_envelope(length, max_length),
    )(vectors, species, senders, receivers).array, axis=1)[:, 0]




def main():
    Node = namedtuple("Node", ["positions", "species"])
    Edge = namedtuple("Edge", ["shifts"])
    Globals = namedtuple("Globals", ["cell"])

    graph = jraph.GraphsTuple(
        nodes=Node(
            positions=jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
            species=jnp.array([0, 1, 0]),
        ),
        edges=Edge(shifts=jnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])),
        globals=Globals(cell=jnp.eye(3)[None, :, :]),
        senders=jnp.array([0, 1, 2]),
        receivers=jnp.array([1, 2, 0]),
        n_edge=jnp.array([3]),
        n_node=jnp.array([3]),
    )

    dummy_vectors = e3nn.IrrepsArray("1o", jnp.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]))
    params = energy_model.init(jax.random.PRNGKey(0), dummy_vectors, jnp.array([0, 1, 0]), jnp.array([0, 1, 2]), jnp.array([1, 2, 0]))

    predictions_original = predict_energy_forces_stress(
        lambda vectors, species, senders, receivers: energy_model.apply(params, vectors, species, senders, receivers),
        graph
    )
    
    predictions_eps = predict_energy_forces_stress_eps(
        lambda vectors, species, senders, receivers: energy_model.apply(params, vectors, species, senders, receivers),
        graph
    )

    print("original")
    print("energy:", predictions_original["energy"])
    print("forces:", predictions_original["forces"])
    print("stress:", predictions_original["stress"])
    
    print("\neps")
    print("energy:", predictions_eps["energy"])
    print("forces:", predictions_eps["forces"])
    print("stress:", predictions_eps["stress"])
    

if __name__ == "__main__":
    main()
```

You will find the above prints matching forces only if the -1.0 is removed from the stress prediction, as is included in this PR. Otherwise, the stress and predicted stress are off by a factor of -1.

```
mace-jax $ uv run --script tmp.py                             
original
energy: [-0.0146414]
forces: [[ 0.29861495 -0.03509867 -0.        ]
 [-0.1243711  -0.17424385 -0.        ]
 [-0.17424385  0.20934252 -0.        ]]
stress: [[[ 0.1243711   0.17424385  0.        ]
  [ 0.17424385 -0.20934252  0.        ]
  [ 0.          0.          0.        ]]]

eps
energy: [-0.0146414]
forces: [[ 0.29861495 -0.03509867 -0.        ]
 [-0.1243711  -0.17424385 -0.        ]
 [-0.17424385  0.20934252 -0.        ]]
stress: [[[ 0.1243711   0.17424385  0.        ]
  [ 0.17424385 -0.20934252  0.        ]
  [ 0.          0.          0.        ]]]
```

I have also verified that my stress implementation above results in a much lower stress MAE when used within my [nequix](https://github.com/atomicarchitects/nequix) repo than when the negative version is used.

It seems this method of computing stress has [propagated](https://github.com/search?q=%22stress+%3D+-1.0+%2F+det+*+viriel%22&type=code).