### PR TITLE
Fix traced-index crash in radial transforms and torch/mace import errors in the torch→JAX converter

### DIFF
--- a/mace_jax/cli/mace_jax_from_torch.py
+++ b/mace_jax/cli/mace_jax_from_torch.py
@@ -8,7 +8,7 @@ import json
 import warnings
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
@@ -21,6 +21,7 @@ warnings.filterwarnings(
     category=UserWarning,
 )
 
+import torch
 from flax import nnx, serialization
 from mace.tools.scripts_utils import extract_config_mace_model
 
@@ -32,9 +33,6 @@ from mace_jax.tools.model_builder import (
     _build_jax_model,
     _prepare_template_data,
 )
-
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    import torch
 
 
 def _load_torch_model_from_foundations(
@@ -135,12 +133,6 @@ def convert_model(
     *,
     cueq_config: CuEquivarianceConfig | None = None,
 ):
-    try:
-        import torch  # noqa: PLC0415
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
-        raise ModuleNotFoundError(
-            'Torch is required to convert models from torch checkpoints.'
-        ) from exc
     _maybe_update_hidden_irreps_from_torch(torch_model, config)
 
     try:
@@ -199,12 +191,6 @@ def main():
     args = parser.parse_args()
 
     if args.torch_model:
-        try:
-            import torch  # noqa: PLC0415
-        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
-            raise ModuleNotFoundError(
-                'Torch is required to load torch checkpoints.'
-            ) from exc
         bundle = torch.load(args.torch_model, map_location='cpu')
         torch_model = (
             bundle['model']

--- a/mace_jax/modules/radial.py
+++ b/mace_jax/modules/radial.py
@@ -266,7 +266,9 @@ class ZBLBasis(nnx.Module):
 
         v_edges = (14.3996 * Z_u * Z_v) / x * phi
 
-        r_max = self._covalent_radii[Z_u] + self._covalent_radii[Z_v]
+        # See AgnesiTransform.__call__ for why this coercion is needed.
+        covalent_radii = jnp.asarray(self._covalent_radii, dtype=x.dtype)
+        r_max = covalent_radii[Z_u] + covalent_radii[Z_v]
         envelope = PolynomialCutoff.calculate_envelope(
             x, r_max.astype(x.dtype), jnp.array(float(self.p), dtype=x.dtype)
         )
@@ -348,7 +350,8 @@ class AgnesiTransform(nnx.Module):
         q = q.astype(x.dtype)
         p = p.astype(x.dtype)
 
-        r_0 = 0.5 * (self._covalent_radii[Z_u] + self._covalent_radii[Z_v])
+        covalent_radii = jnp.asarray(self._covalent_radii, dtype=x.dtype)
+        r_0 = 0.5 * (covalent_radii[Z_u] + covalent_radii[Z_v])
         r_over_r_0 = x / r_0
 
         numerator = a * jnp.power(r_over_r_0, q)
@@ -401,7 +404,9 @@ class SoftTransform(nnx.Module):
         ].reshape(-1, 1)
         Z_u = node_atomic_numbers[sender].astype(jnp.int32)
         Z_v = node_atomic_numbers[receiver].astype(jnp.int32)
-        return self._covalent_radii[Z_u] + self._covalent_radii[Z_v]
+        # See AgnesiTransform.__call__ for why this coercion is needed.
+        covalent_radii = jnp.asarray(self._covalent_radii)
+        return covalent_radii[Z_u] + covalent_radii[Z_v]
 
     def __call__(
         self,

--- a/mace_jax/modules/radial.py
+++ b/mace_jax/modules/radial.py
@@ -234,7 +234,7 @@ class ZBLBasis(nnx.Module):
 
         if node_attrs_index is None:
             node_attrs_index = jnp.argmax(node_attrs, axis=1)
-        node_atomic_numbers = atomic_numbers[
+        node_atomic_numbers = jnp.asarray(atomic_numbers)[
             jnp.asarray(node_attrs_index, dtype=jnp.int32).reshape(-1)
         ][..., None]
         Z_u = node_atomic_numbers[sender].astype(jnp.int32)
@@ -328,7 +328,7 @@ class AgnesiTransform(nnx.Module):
 
         if node_attrs_index is None:
             node_attrs_index = jnp.argmax(node_attrs, axis=1)
-        node_atomic_numbers = atomic_numbers[
+        node_atomic_numbers = jnp.asarray(atomic_numbers)[
             jnp.asarray(node_attrs_index, dtype=jnp.int32).reshape(-1)
         ][..., None]
         Z_u = node_atomic_numbers[sender].astype(jnp.int32)
@@ -396,7 +396,7 @@ class SoftTransform(nnx.Module):
         sender, receiver = edge_index
         if node_attrs_index is None:
             node_attrs_index = jnp.argmax(node_attrs, axis=1)
-        node_atomic_numbers = atomic_numbers[
+        node_atomic_numbers = jnp.asarray(atomic_numbers)[
             jnp.asarray(node_attrs_index, dtype=jnp.int32).reshape(-1)
         ].reshape(-1, 1)
         Z_u = node_atomic_numbers[sender].astype(jnp.int32)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ test =
     pytest
     pytest-xdist
     nox
+    mace-torch
 plot =
     matplotlib
     pandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,12 @@ install_requires =
 [options.extras_require]
 torch-cuda12 =
     torch
+    mace-torch
     cuequivariance-torch>=0.10,<0.11
     cuequivariance-ops-torch-cu12>=0.10,<0.11
 torch-cuda13 =
     torch
+    mace-torch
     cuequivariance-torch>=0.10,<0.11
     cuequivariance-ops-torch-cu13>=0.10,<0.11
 test =

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1,0 +1,78 @@
+"""Regression tests for the two bugs.
+
+(1) ``AgnesiTransform.__call__`` indexes the ``atomic_numbers`` argument
+    (a Python list arriving from the model config) with a traced JAX index.
+    Inside a traced region (``jax.jit`` / ``pmap`` / ``shard_map``) that
+    Python-list ``__getitem__`` calls ``__array__`` on the tracer and raises
+    ``TracerArrayConversionError``.
+
+(2) ``mace_jax.cli.mace_jax_from_torch._serialize_for_json`` references
+    ``torch.Tensor`` / ``torch.device`` / ``torch.dtype`` / ``torch.Size``,
+    but the module only imports ``torch`` *inside* ``main()``. Calling the
+    function from anywhere else (e.g. ``remote_handler.scripts.mace.
+    mace_utils.convert_torch_model_to_jax_bundle``) raises ``NameError``.
+
+
+Reproduce via:
+```bash
+conda create --name mace_jax_fix python=3.13
+conda activate mace_jax_fix
+pip install -e .[jax-cuda12,torch-cuda12,test]
+pytest test/test_bugs.py
+```
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+
+def test_agnesi_transform_traced_atomic_numbers():
+    """The transform must work when its caller passes ``atomic_numbers`` as a
+    Python list (which is what ``mace_jax/modules/models.py`` does) and
+    ``node_attrs_index`` as a traced array (which is what happens under
+    ``jit``/``pmap``).
+    """
+    from mace_jax.modules.radial import AgnesiTransform
+
+    transform = AgnesiTransform(trainable=False)
+
+    # Two atoms in a single edge, two distinct species (Z=50 Sn, Z=8 O).
+    edge_lengths = jnp.array([[2.5]], dtype=jnp.float32)
+    node_attrs = jnp.array([[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+    edge_index = jnp.array([[0], [1]], dtype=jnp.int32)
+    node_attrs_index = jnp.array([0, 1], dtype=jnp.int32)
+
+    # ``atomic_numbers`` arrives as a Python list / tuple from the config --
+    # NOT a jnp.array. This is the exact shape of the bug.
+    atomic_numbers = [50, 8]
+
+    @jax.jit
+    def f(x, na, ei, idx):
+        return transform(
+            x, na, ei,
+            atomic_numbers=atomic_numbers,
+            node_attrs_index=idx,
+        )
+
+    out = f(edge_lengths, node_attrs, edge_index, node_attrs_index)
+    assert out.shape == (1, 1)
+    assert jnp.isfinite(out).all()
+
+
+def test_serialize_for_json_torch_namespace():
+    """The serializer must be callable as a library function (i.e. without
+    going through ``main()``, which is the only place ``torch`` is imported).
+    """
+    torch = pytest.importorskip("torch")
+    from mace_jax.cli.mace_jax_from_torch import _serialize_for_json
+
+    # The torch.Tensor branch (line ~103) is the most direct trigger; if torch
+    # is bound in the module namespace this returns a list, otherwise NameError.
+    result = _serialize_for_json(torch.tensor([1.0, 2.0, 3.0]))
+    assert result == [1.0, 2.0, 3.0]
+
+    # dtype branch -- separate code path that ALSO needs ``torch``.
+    assert _serialize_for_json(torch.float32) == "float32"

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1,16 +1,24 @@
-"""Regression tests for the two bugs.
+"""Regression tests for the fixed bugs.
 
-(1) ``AgnesiTransform.__call__`` indexes the ``atomic_numbers`` argument
-    (a Python list arriving from the model config) with a traced JAX index.
-    Inside a traced region (``jax.jit`` / ``pmap`` / ``shard_map``) that
-    Python-list ``__getitem__`` calls ``__array__`` on the tracer and raises
-    ``TracerArrayConversionError``.
+(1) The radial transforms (``AgnesiTransform`` / ``SoftTransform`` /
+    ``ZBLBasis``) index the array attributes ``_atomic_numbers`` and
+    ``_covalent_radii`` with traced species indices. Both attributes are plain
+    arrays (not ``nnx.Param``): a freshly built model holds them as *JAX*
+    arrays (which tolerate tracer indexing), but after a model is serialized
+    and reloaded through the bundle loader they come back as *NumPy* arrays.
+    Indexing a NumPy array with a traced index inside a traced region
+    (``jax.jit`` / ``pmap`` / ``shard_map``) raises
+    ``TracerArrayConversionError``. The fix coerces both with ``jnp.asarray``.
+
+    Note: ``mace_jax/modules/models.py`` passes ``self._atomic_numbers`` (a
+    JAX/NumPy array), never a Python list -- so this only reproduces through
+    the full build -> serialize -> reload -> ``jit`` path below.
 
 (2) ``mace_jax.cli.mace_jax_from_torch._serialize_for_json`` references
     ``torch.Tensor`` / ``torch.device`` / ``torch.dtype`` / ``torch.Size``,
-    but the module only imports ``torch`` *inside* ``main()``. Calling the
+    but the module only imported ``torch`` *inside* ``main()``. Calling the
     function from anywhere else (e.g. ``remote_handler.scripts.mace.
-    mace_utils.convert_torch_model_to_jax_bundle``) raises ``NameError``.
+    mace_utils.convert_torch_model_to_jax_bundle``) raised ``NameError``.
 
 
 Reproduce via:
@@ -29,39 +37,6 @@ import jax.numpy as jnp
 import pytest
 
 
-def test_agnesi_transform_traced_atomic_numbers():
-    """The transform must work when its caller passes ``atomic_numbers`` as a
-    Python list (which is what ``mace_jax/modules/models.py`` does) and
-    ``node_attrs_index`` as a traced array (which is what happens under
-    ``jit``/``pmap``).
-    """
-    from mace_jax.modules.radial import AgnesiTransform
-
-    transform = AgnesiTransform(trainable=False)
-
-    # Two atoms in a single edge, two distinct species (Z=50 Sn, Z=8 O).
-    edge_lengths = jnp.array([[2.5]], dtype=jnp.float32)
-    node_attrs = jnp.array([[1.0, 0.0], [0.0, 1.0]], dtype=jnp.float32)
-    edge_index = jnp.array([[0], [1]], dtype=jnp.int32)
-    node_attrs_index = jnp.array([0, 1], dtype=jnp.int32)
-
-    # ``atomic_numbers`` arrives as a Python list / tuple from the config --
-    # NOT a jnp.array. This is the exact shape of the bug.
-    atomic_numbers = [50, 8]
-
-    @jax.jit
-    def f(x, na, ei, idx):
-        return transform(
-            x, na, ei,
-            atomic_numbers=atomic_numbers,
-            node_attrs_index=idx,
-        )
-
-    out = f(edge_lengths, node_attrs, edge_index, node_attrs_index)
-    assert out.shape == (1, 1)
-    assert jnp.isfinite(out).all()
-
-
 def test_serialize_for_json_torch_namespace():
     """The serializer must be callable as a library function (i.e. without
     going through ``main()``, which is the only place ``torch`` is imported).
@@ -76,3 +51,100 @@ def test_serialize_for_json_torch_namespace():
 
     # dtype branch -- separate code path that ALSO needs ``torch``.
     assert _serialize_for_json(torch.float32) == "float32"
+
+
+# ---------------------------------------------------------------------------
+# (1) The covalent-radii transforms (``AgnesiTransform`` / ``SoftTransform`` /
+#     ``ZBLBasis``) index the array attributes ``_atomic_numbers`` and
+#     ``_covalent_radii`` with traced species indices. In a freshly built model
+#     both are *JAX* arrays, so the indexing happens to work; after a model is
+#     serialized and reloaded through the real bundle loader they come back as
+#     *NumPy* arrays, and indexing a NumPy array with a traced index under
+#     ``jit``/``vmap``/``pmap`` raises ``TracerArrayConversionError``
+#     (radial.py: ``atomic_numbers[...]`` and ``covalent_radii[Z_u]``).
+#
+# This only reproduces through the full build -> serialize -> reload -> ``jit``
+# path below; a directly constructed transform never produces the NumPy state.
+# The test fails on the pre-fix commits and passes once both attributes are
+# coerced with ``jnp.asarray``.
+# ---------------------------------------------------------------------------
+
+
+def _small_config(**overrides):
+    config = {
+        'r_max': 4.0,
+        'num_bessel': 2,
+        'num_polynomial_cutoff': 2,
+        'max_ell': 1,
+        'interaction_cls': 'RealAgnosticInteractionBlock',
+        'interaction_cls_first': 'RealAgnosticInteractionBlock',
+        'num_interactions': 1,
+        'num_elements': 2,
+        'hidden_irreps': '2x0e',
+        'edge_irreps': None,
+        'MLP_irreps': '2x0e',
+        'atomic_numbers': [1, 8],
+        'atomic_energies': [0.0, 0.0],
+        'avg_num_neighbors': 1.0,
+        'correlation': 1,
+        'radial_type': 'bessel',
+        'pair_repulsion': False,
+        'distance_transform': None,
+        'use_so3': False,
+        'use_reduced_cg': True,
+        'use_agnostic_product': False,
+        'use_last_readout_only': False,
+        'use_embedding_readout': False,
+        'gate': 'silu',
+        'apply_cutoff': True,
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.mark.parametrize(
+    'overrides',
+    [
+        pytest.param({'distance_transform': 'Agnesi'}, id='agnesi'),
+        pytest.param({'distance_transform': 'Soft'}, id='soft'),
+        pytest.param({'pair_repulsion': True}, id='zbl-pair-repulsion'),
+    ],
+)
+def test_covalent_radii_transform_survives_reload_and_jit(tmp_path, overrides):
+    """A reloaded model whose radial block uses the covalent-radii transforms
+    must be callable under ``jax.jit``.
+
+    The reload is what makes ``_covalent_radii`` a NumPy array (the state that
+    direct construction never produces), so this is the only way to reach the
+    ``TracerArrayConversionError`` the fix addresses.
+    """
+    import json
+
+    from flax import nnx, serialization
+
+    from mace_jax.nnx_utils import state_to_serializable_dict
+    from mace_jax.tools import bundle as bundle_tools
+    from mace_jax.tools import model_builder
+
+    config = _small_config(**overrides)
+    config, _, _ = model_builder._normalize_atomic_config(config)
+
+    model = model_builder._build_jax_model(config, rngs=nnx.Rngs(0))
+    _, state = nnx.split(model)
+    payload = state_to_serializable_dict(state)
+
+    (tmp_path / 'config.json').write_text(json.dumps(config))
+    (tmp_path / 'params.msgpack').write_bytes(serialization.to_bytes(payload))
+
+    bundle = bundle_tools.load_model_bundle(str(tmp_path), dtype='float64')
+    template = model_builder._prepare_template_data(config)
+
+    @jax.jit
+    def energy(data):
+        out, _ = bundle.graphdef.apply(bundle.params)(
+            data, compute_force=False, compute_stress=False
+        )
+        return out['energy']
+
+    result = energy(template)
+    assert jnp.isfinite(result).all()


### PR DESCRIPTION
# Fix traced-index crash in radial transforms and `torch`/`mace` import errors in the torch→JAX converter

## Summary

This PR fixes three issues found while converting and loading a Torch foundation model in `mace-jax`:

1. Radial transforms crash with `TracerArrayConversionError` when a reloaded model is run under `jit`/`vmap`/`pmap`, because their `_atomic_numbers` / `_covalent_radii` attributes come back as NumPy arrays and are indexed by traced species indices.
2. `_serialize_for_json` in the torch→JAX converter raises `NameError` when used as a library function, because `torch` was only imported inside `main()`.
3. The converter module hard-imports `mace` (mace-torch) at module scope, but `mace-torch` was not declared in any install extra — so the module failed to import at all, masking issue 2.

Issues 1 and 2 are covered by regression tests in `tests/test_bugs.py`; issue 3 is addressed by declaring the missing dependency.

## Bug 1 — `TracerArrayConversionError` from radial transforms after model reload

I realized this bug when trying to load the converted `medium-0b3` foundation model. The latter contains some radial transforms, which caused `TracerArrayConversionError`s when loading `mace-jax`'s converted model bundle. As far as I understand, this is caused by the `bundle_tools.load_model_bundle`, which loads the serialized model, returning numpy arrays for `_atomic_numbers` and `_covalent_radii`.

The radial transforms (`ZBLBasis`, `AgnesiTransform`, `SoftTransform`) index those two attributes with the per-edge species indices. In a freshly built model `_atomic_numbers` / `_covalent_radii` are JAX arrays — which tolerate indexing by a tracer — but they are plain array attributes (not `nnx.Param`), so after serialize→reload they come back as NumPy arrays. Once the graph data is traced (`jit` / `vmap` / `pmap`, as in the real caller) the species indices are tracers, and indexing a NumPy array with a traced index calls `__array__` on the tracer and raises `TracerArrayConversionError`. This is why a directly constructed transform never hits it — only the reloaded model does.

**Fix:** coerce the indexed attribute with `jnp.asarray(...)` before the gather, at every affected site in `mace_jax/modules/radial.py` (`_atomic_numbers` and `_covalent_radii`, across all three transforms).

## Bug 2 — `NameError: name 'torch' is not defined` in `_serialize_for_json`

While I think Bug 1 is a serious problem, Bug 2 is probably more of a choice that has been made. 
Maybe there is a good reason to do it in the way it was, but I personally don't really see why one would lazily load `torch` in the JAX->torch conversion CLI. 
It definitely prevented the usage of the functionality in downstream applications, so I sketched a solution with a module top level import of torch. 

`mace_jax/cli/mace_jax_from_torch._serialize_for_json` references `torch.Tensor` / `torch.device` / `torch.dtype` / `torch.Size`, but `torch` was only imported lazily inside `main()`. Calling the serializer as a library function (e.g. from an external conversion helper, not through the CLI `main()`) raised `NameError`.

**Fix:** import `torch` at module top level. Since this module is the torch→JAX converter, `torch` is a genuine hard requirement; the previous lazy imports were also redundant because the module already imported `mace` (which depends on `torch`) at import time. The now-dead lazy `import torch` / `ModuleNotFoundError` guards were removed.

## Bug 3 (latent) — undeclared `mace-torch` dependency 

`mace_jax_from_torch.py` imports `from mace.tools.scripts_utils import extract_config_mace_model` at module scope, but `mace-torch` was not declared in any install extra. As a result, importing the module failed with `ModuleNotFoundError: No module named 'mace'`. Having `mace-torch` installed is also crucial to run the test suite.

**Fix:** declare `mace-torch` in the `torch-cuda12`, `torch-cuda13`, and `test` extras in `setup.cfg`. I guess, if you decide to install torch deps, you are also willing to install mace-torch.

## Changes

- `mace_jax/modules/radial.py` — wrap both `_atomic_numbers` and `_covalent_radii` in `jnp.asarray(...)` before the traced-index gathers, across `ZBLBasis`, `AgnesiTransform`, and `SoftTransform`.
- `mace_jax/cli/mace_jax_from_torch.py` — move `torch` and `extract_config_mace_model` imports to module top level; drop the dead lazy-import guards.
- `setup.cfg` — add `mace-torch` to the `torch-cuda12` / `torch-cuda13` / `test` extras.
- `tests/test_bugs.py` — regression tests (see below).

## Testing

```bash
pip install -e .[jax-cuda12,torch-cuda12,test]
pytest tests/test_bugs.py
```

The regression tests in `tests/test_bugs.py`:

- `test_covalent_radii_transform_survives_reload_and_jit[agnesi|soft|zbl-pair-repulsion]` — builds a small MACE model with each transform, round-trips it through the real `load_model_bundle` (which is what turns the attributes into NumPy arrays), and runs the energy under `jit` with the graph **data** as the traced argument. Verified to fail on the pre-fix commit with `TracerArrayConversionError` at the exact `radial.py` index lines, and to pass after the fix.
- `test_serialize_for_json_torch_namespace` — calls `_serialize_for_json` as a library function (Bug 2).

All four pass; The whole test suite is green, except `tests/test_model.py`, which (as probably known) already failed before the changes. 

