### PR TITLE
Enable MACE-MH1 and OpenEquivariance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,25 @@ Notes:
  - `--cueq-layout {mul_ir,ir_mul}` and `--cueq-group {O3,O3_e3nn}` mirror the
    Torch defaults (use `ir_mul`/`O3_e3nn` for `--only_cueq`).
 
+##### OpenEquivariance fused convolution
+
+OpenEquivariance is an opt-in CUDA backend for the fused channel-wise tensor
+product convolution. It does not replace cuequivariance for linear or symmetric
+contraction kernels. Install the pinned packages in this order (the second build
+must not use build isolation):
+
+```sh
+pip install 'openequivariance[jax]==0.6.8'
+pip install 'openequivariance_extjax==0.6.8' --no-build-isolation
+```
+
+Enable it with `--enable-openeq`. The explicit equivalents are
+`--openeq-optimize-all`, `--openeq-conv-fusion`,
+`--openeq-layout=mul_ir`, and `--openeq-group=O3_e3nn`. V1 uses CUDA atomic
+aggregation, supports float32/float64 and force-training derivatives, and is not
+deterministic. ROCm is not qualified. Unsupported configurations and missing or
+failed OpenEquivariance kernels raise an error; there is no silent fallback.
+
 For instance, fine-tuning a Torch foundation model against a new dataset can be done with:
 
 ```sh

--- a/mace_jax/adapters/cuequivariance/symmetric_contraction.py
+++ b/mace_jax/adapters/cuequivariance/symmetric_contraction.py
@@ -41,7 +41,7 @@ from mace_jax.adapters.nnx.torch import (
 from mace_jax.nnx_utils import state_to_pure_dict
 from mace_jax.tools.dtype import default_dtype
 
-from .utility import ir_mul_to_mul_ir
+from .utility import ir_mul_to_mul_ir, mul_ir_to_ir_mul
 
 
 @nxx_auto_import_from_torch(allow_missing_mapper=True)
@@ -317,6 +317,8 @@ class SymmetricContraction(nnx.Module):
             out_ir_mul,
             Irreps(self.irreps_out_o3_str),
         )
+        if self.input_layout == 'ir_mul':
+            return mul_ir_to_ir_mul(out_mul_ir, Irreps(self.irreps_out_o3_str))
         return out_mul_ir
 
     def _features_to_rep(self, x: jnp.ndarray, dtype: jnp.dtype) -> cuex.RepArray:

--- a/mace_jax/adapters/e3nn/nn/_fc.py
+++ b/mace_jax/adapters/e3nn/nn/_fc.py
@@ -40,6 +40,7 @@ class Layer(nnx.Module):
         act: Callable | None,
         var_in: float,
         var_out: float,
+        output_permutation: Sequence[int] | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -48,6 +49,9 @@ class Layer(nnx.Module):
         self.act = act
         self.var_in = var_in
         self.var_out = var_out
+        self.output_permutation = (
+            tuple(output_permutation) if output_permutation is not None else None
+        )
         self._use_activation = self.act is not None
         if self._use_activation:
             normalized = normalize2mom(self.act)  # compute reference constant
@@ -74,6 +78,9 @@ class Layer(nnx.Module):
 
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         weight = self.weight
+        if self.output_permutation is not None:
+            # Reorder the small projection matrix, not the batch-sized output.
+            weight = jnp.take(weight, jnp.asarray(self.output_permutation), axis=-1)
 
         if self._use_activation:
             scaled = weight / jnp.sqrt(self.h_in * self.var_in)
@@ -126,6 +133,7 @@ class FullyConnectedNet(nnx.Module):
         variance_in: float = 1.0,
         variance_out: float = 1.0,
         out_act: bool = False,
+        output_permutation: Sequence[int] | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -134,6 +142,9 @@ class FullyConnectedNet(nnx.Module):
         self.variance_in = variance_in
         self.variance_out = variance_out
         self.out_act = out_act
+        self.output_permutation = (
+            tuple(output_permutation) if output_permutation is not None else None
+        )
         if len(self.hs) < 2:
             raise ValueError('hs must contain at least input and output dimensions.')
 
@@ -154,6 +165,7 @@ class FullyConnectedNet(nnx.Module):
                 act=activation,
                 var_in=var_in,
                 var_out=var_out,
+                output_permutation=self.output_permutation if is_last else None,
                 rngs=rngs,
             )
             layers.append(layer)

--- a/mace_jax/adapters/e3nn/nn/_gate.py
+++ b/mace_jax/adapters/e3nn/nn/_gate.py
@@ -122,53 +122,50 @@ class Gate(nnx.Module):
         self.irreps_gated = irreps_gated
         self.normalize_act = normalize_act
 
-        irreps_scalars = Irreps(self.irreps_scalars).simplify()
-        irreps_gates = Irreps(self.irreps_gates).simplify()
-        irreps_gated = Irreps(self.irreps_gated).simplify()
+        irreps_scalars_in = Irreps(self.irreps_scalars)
+        irreps_gates_in = Irreps(self.irreps_gates)
+        irreps_gated_in = Irreps(self.irreps_gated)
 
-        max_gate_l = max((mul_ir.ir.l for mul_ir in irreps_gates), default=0)
-        max_scalar_l = max((mul_ir.ir.l for mul_ir in irreps_scalars), default=0)
-
-        if len(irreps_gates) > 0 and max_gate_l > 0:
-            raise ValueError(f'Gate scalars must be scalars, got {irreps_gates}')
-        if len(irreps_scalars) > 0 and max_scalar_l > 0:
-            raise ValueError(f'Scalars must be scalars, got {irreps_scalars}')
-        if len(irreps_gates) != len(irreps_gated):
+        if irreps_gates_in.num_irreps != irreps_gated_in.num_irreps:
             raise ValueError(
-                f'Mismatch: {len(irreps_gated)} irreps in gated, '
-                f'{len(irreps_gates)} in gates'
+                f'Mismatch: {irreps_gated_in.num_irreps} irreps in gated, '
+                f'{irreps_gates_in.num_irreps} in gates'
             )
+        if len(irreps_gates_in) > 0 and irreps_gates_in.lmax > 0:
+            raise ValueError(f'Gate scalars must be scalars, got {irreps_gates_in}')
+        if len(irreps_scalars_in) > 0 and irreps_scalars_in.lmax > 0:
+            raise ValueError(f'Scalars must be scalars, got {irreps_scalars_in}')
 
-        self._irreps_scalars = irreps_scalars
-        self._irreps_gates = irreps_gates
-        self._irreps_gated = irreps_gated
+        self._sortcut = _Sortcut(
+            irreps_scalars_in,
+            irreps_gates_in,
+            irreps_gated_in,
+        )
+        self._irreps_scalars, self._irreps_gates, self._irreps_gated = (
+            self._sortcut.irreps_outs
+        )
+        self._irreps_in = self._sortcut.irreps_in
+        self._irreps_gated_input = irreps_gated_in
 
         self._scalar_activation = Activation(
-            self._irreps_scalars,
+            irreps_scalars_in,
             self.act_scalars,
             normalize_act=self.normalize_act,
         )
         self._gate_activation = Activation(
-            self._irreps_gates,
+            irreps_gates_in,
             self.act_gates,
             normalize_act=self.normalize_act,
         )
 
-        self._sortcut = _Sortcut(
-            self._irreps_scalars,
-            self._irreps_gates,
-            self._irreps_gated,
-        )
-
-        self._irreps_in = self._sortcut.irreps_in
         self._irreps_scalars_out = self._scalar_activation.irreps_out
         self._irreps_gates_out = self._gate_activation.irreps_out
 
-        irreps_gated_dim = _as_irreps(self._irreps_gated).dim
+        irreps_gated_dim = _as_irreps(self._irreps_gated_input).dim
         irreps_gates_out_dim = _as_irreps(self._irreps_gates_out).dim
 
         if irreps_gated_dim > 0 and irreps_gates_out_dim > 0:
-            sample_gated = e3nn.zeros(_as_irreps(self._irreps_gated), ())
+            sample_gated = e3nn.zeros(_as_irreps(self._irreps_gated_input), ())
             sample_gates = e3nn.zeros(_as_irreps(self._irreps_gates_out), ())
             self._mul_irreps_out = e3nn.elementwise_tensor_product(
                 sample_gated,
@@ -214,7 +211,7 @@ class Gate(nnx.Module):
             outputs.append(scalars_act)
 
         if gates_act.shape[-1] > 0 and gated.shape[-1] > 0:
-            gated_ir = e3nn.IrrepsArray(_as_irreps(self._irreps_gated), gated)
+            gated_ir = e3nn.IrrepsArray(_as_irreps(self._irreps_gated_input), gated)
             gates_ir = e3nn.IrrepsArray(_as_irreps(self._irreps_gates_out), gates_act)
             gated_prod = e3nn.elementwise_tensor_product(gated_ir, gates_ir).array
             if gated_prod.shape[-1] > 0:

--- a/mace_jax/adapters/openequivariance/__init__.py
+++ b/mace_jax/adapters/openequivariance/__init__.py
@@ -1,0 +1,9 @@
+"""Supported OpenEquivariance adapters.
+
+Standalone and fully connected tensor products are not public because the
+OpenEquivariance 0.6.8 backward path is unsafe for general multi-problem use.
+"""
+
+from .tensor_product import TensorProduct
+
+__all__ = ['TensorProduct']

--- a/mace_jax/adapters/openequivariance/fully_connected_tensor_product.py
+++ b/mace_jax/adapters/openequivariance/fully_connected_tensor_product.py
@@ -1,0 +1,57 @@
+"""Unsupported OpenEquivariance FCTP used only by failure diagnostics.
+
+Do not expose this module through the public adapter package. OEQ 0.6.8 can
+silently corrupt its input gradients when multiple FCTP problems execute in a
+single process. The implementation remains isolated here so the upstream
+regression reproducer can exercise the affected backend.
+"""
+
+from __future__ import annotations
+
+from e3nn_jax import Irreps
+from flax import nnx
+
+from mace_jax.adapters.nnx.torch import nxx_auto_import_from_torch
+
+from .tensor_product import TensorProduct
+
+
+@nxx_auto_import_from_torch(allow_missing_mapper=True)
+class FullyConnectedTensorProduct(TensorProduct):
+    """Diagnostic-only weighted ``uvw`` tensor product."""
+
+    def __init__(
+        self,
+        irreps_in1: Irreps,
+        irreps_in2: Irreps,
+        irreps_out: Irreps,
+        shared_weights: bool = True,
+        internal_weights: bool = True,
+        *,
+        layout: str = 'mul_ir',
+        group: str = 'O3_e3nn',
+        rngs: nnx.Rngs | None = None,
+    ) -> None:
+        irreps_in1 = Irreps(irreps_in1)
+        irreps_in2 = Irreps(irreps_in2)
+        irreps_out = Irreps(irreps_out)
+        instructions = [
+            (i1, i2, iout, 'uvw', True, 1.0)
+            for i1, (_, ir1) in enumerate(irreps_in1)
+            for i2, (_, ir2) in enumerate(irreps_in2)
+            for iout, (_, irout) in enumerate(irreps_out)
+            if irout in ir1 * ir2
+        ]
+        super().__init__(
+            irreps_in1,
+            irreps_in2,
+            irreps_out,
+            instructions=instructions,
+            shared_weights=shared_weights,
+            internal_weights=internal_weights,
+            conv_fusion=False,
+            layout=layout,
+            group=group,
+            rngs=rngs,
+            _unsafe_allow_standalone_for_diagnostics=True,
+        )

--- a/mace_jax/adapters/openequivariance/problem.py
+++ b/mace_jax/adapters/openequivariance/problem.py
@@ -1,0 +1,132 @@
+"""Shared OpenEquivariance tensor-product problem construction."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+from e3nn_jax import Irreps
+
+from mace_jax.tools.dtype import default_dtype
+
+
+Instruction = tuple[int, int, int, str, bool, float]
+
+
+def load_openeq():
+    """Import the optional JAX backend without importing its Torch bindings."""
+    os.environ.setdefault('OEQ_NOTORCH', '1')
+    try:
+        import openequivariance as oeq
+        import openequivariance.jax as oeq_jax
+    except (ImportError, OSError, AttributeError) as exc:
+        raise RuntimeError(
+            'OpenEquivariance was selected but its JAX packages are unavailable. '
+            'Install openequivariance[jax]==0.6.8, then install '
+            'openequivariance_extjax==0.6.8 with --no-build-isolation.'
+        ) from exc
+    return oeq, oeq_jax
+
+
+def normalize_instructions(
+    instructions: Sequence[Sequence[Any]] | None,
+    *,
+    allowed_modes: frozenset[str] | None = None,
+) -> tuple[Instruction, ...]:
+    """Validate and normalize e3nn tensor-product instructions."""
+    if instructions is None:
+        raise ValueError('OpenEquivariance requires explicit instructions.')
+    result = []
+    for instruction in instructions:
+        if len(instruction) == 5:
+            i1, i2, iout, mode, weighted = instruction
+            path_weight = 1.0
+        elif len(instruction) == 6:
+            i1, i2, iout, mode, weighted, path_weight = instruction
+        else:
+            raise ValueError(
+                'OpenEquivariance instructions must have length 5 or 6; '
+                f'got {len(instruction)}.'
+            )
+        normalized = (
+            int(i1),
+            int(i2),
+            int(iout),
+            str(mode),
+            bool(weighted),
+            float(path_weight),
+        )
+        if not normalized[4]:
+            raise ValueError('OpenEquivariance adapters require weighted instructions.')
+        if allowed_modes is not None and normalized[3] not in allowed_modes:
+            modes = ', '.join(sorted(allowed_modes))
+            raise ValueError(
+                f'OpenEquivariance instruction mode must be one of {modes}; '
+                f'got {normalized[3]!r}.'
+            )
+        result.append(normalized)
+    return tuple(result)
+
+
+def build_tp_problem(
+    irreps_in1: Irreps,
+    irreps_in2: Irreps,
+    irreps_out: Irreps,
+    instructions: Sequence[Sequence[Any]],
+    *,
+    shared_weights: bool,
+    layout: str = 'mul_ir',
+    group: str = 'O3_e3nn',
+    allowed_modes: frozenset[str] | None = None,
+):
+    """Build a strictly validated OpenEquivariance ``TPProblem``."""
+    if layout not in ('mul_ir', 'ir_mul'):
+        raise ValueError(f'OpenEquivariance layout must be mul_ir or ir_mul, got {layout!r}.')
+    if group != 'O3_e3nn':
+        raise ValueError(
+            "OpenEquivariance requires group='O3_e3nn'; " f'got {group!r}.'
+        )
+    dtype = jnp.dtype(default_dtype())
+    if dtype not in (jnp.dtype(jnp.float32), jnp.dtype(jnp.float64)):
+        raise TypeError(
+            'OpenEquivariance supports only float32 and float64; '
+            f'received {dtype}.'
+        )
+    np_dtype = np.float64 if dtype == jnp.dtype(jnp.float64) else np.float32
+    normalized = normalize_instructions(instructions, allowed_modes=allowed_modes)
+    oeq, oeq_jax = load_openeq()
+    try:
+        problem = oeq.TPProblem(
+            oeq.Irreps(str(Irreps(irreps_in1))),
+            oeq.Irreps(str(Irreps(irreps_in2))),
+            oeq.Irreps(str(Irreps(irreps_out))),
+            normalized,
+            shared_weights=bool(shared_weights),
+            internal_weights=False,
+            irrep_normalization='component',
+            path_normalization='element',
+            irrep_dtype=np_dtype,
+            weight_dtype=np_dtype,
+            layout=layout,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            'OpenEquivariance could not construct the requested CUDA tensor product.'
+        ) from exc
+    return problem, oeq_jax, dtype, normalized
+
+
+def weight_permutation(operator, weight_numel: int, *, shared_weights: bool) -> tuple[int, ...]:
+    """Return indices mapping canonical e3nn weights to backend weight order."""
+    canonical = np.arange(weight_numel, dtype=np.int32)
+    candidate = canonical if shared_weights else canonical[None, :]
+    reordered = operator.reorder_weights_from_e3nn(
+        candidate, has_batch_dim=not shared_weights
+    )
+    permutation = tuple(int(x) for x in np.asarray(reordered).reshape(-1))
+    if sorted(permutation) != list(range(weight_numel)):
+        raise RuntimeError('OpenEquivariance returned an invalid weight permutation.')
+    return permutation

--- a/mace_jax/adapters/openequivariance/tensor_product.py
+++ b/mace_jax/adapters/openequivariance/tensor_product.py
@@ -1,0 +1,181 @@
+"""Strict OpenEquivariance tensor-product adapters."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from e3nn_jax import Irreps
+from flax import nnx
+
+from mace_jax.adapters.nnx.torch import nxx_auto_import_from_torch
+
+from .problem import build_tp_problem, weight_permutation
+
+
+@nxx_auto_import_from_torch(allow_missing_mapper=True)
+class TensorProduct(nnx.Module):
+    """OpenEquivariance TP, optionally fused with graph aggregation."""
+
+    def __init__(
+        self,
+        irreps_in1: Irreps,
+        irreps_in2: Irreps,
+        irreps_out: Irreps,
+        shared_weights: bool = False,
+        internal_weights: bool = False,
+        instructions=None,
+        *,
+        conv_fusion: bool = True,
+        layout: str = 'mul_ir',
+        group: str = 'O3_e3nn',
+        rngs: nnx.Rngs | None = None,
+        _unsafe_allow_standalone_for_diagnostics: bool = False,
+    ) -> None:
+        if not conv_fusion and not _unsafe_allow_standalone_for_diagnostics:
+            raise ValueError(
+                'Standalone OpenEquivariance tensor products are currently '
+                'unsupported because the OpenEquivariance 0.6.8 backward path '
+                'is unsafe for general multi-problem execution.'
+            )
+        if internal_weights and not shared_weights:
+            raise ValueError(
+                'TensorProduct requires shared_weights=True when internal_weights=True'
+            )
+        self.irreps_in1 = Irreps(irreps_in1)
+        self.irreps_in2 = Irreps(irreps_in2)
+        self.irreps_out = Irreps(irreps_out)
+        self.shared_weights = bool(shared_weights)
+        self.internal_weights = bool(internal_weights)
+        self.conv_fusion = bool(conv_fusion)
+        self.layout = layout
+        allowed_modes = frozenset({'uvu'}) if self.conv_fusion else None
+        self.problem, oeq_jax, self.dtype, self.instructions = build_tp_problem(
+            self.irreps_in1,
+            self.irreps_in2,
+            self.irreps_out,
+            instructions,
+            shared_weights=self.shared_weights,
+            layout=layout,
+            group=group,
+            allowed_modes=allowed_modes,
+        )
+        try:
+            if self.conv_fusion:
+                self.operator = oeq_jax.TensorProductConv(
+                    self.problem, deterministic=False, requires_jvp=True
+                )
+                self._conv_method = 'openeq_atomic'
+            else:
+                self.operator = oeq_jax.TensorProduct(self.problem)
+                self._conv_method = 'openeq_tp'
+        except Exception as exc:
+            raise RuntimeError(
+                'OpenEquivariance could not compile the requested CUDA tensor product.'
+            ) from exc
+        self.weight_numel = int(self.problem.weight_numel)
+        self.weight_permutation = weight_permutation(
+            self.operator,
+            self.weight_numel,
+            shared_weights=self.shared_weights,
+        )
+        self.expects_projected_weights = bool(
+            not self.shared_weights and not self.internal_weights
+        )
+        self.projection_permutation = (
+            self.weight_permutation if self.expects_projected_weights else None
+        )
+        if self.internal_weights:
+            if rngs is None:
+                raise ValueError('rngs is required when internal_weights=True')
+            # Parameters deliberately remain in canonical e3nn order.
+            self.weight = nnx.Param(
+                jax.random.normal(rngs(), (1, self.weight_numel), dtype=self.dtype)
+            )
+        else:
+            self.weight = None
+
+    def _weights(self, weights, batch_size: int, *, already_reordered: bool):
+        if self.internal_weights:
+            if weights is not None:
+                raise ValueError('weights must be None when internal_weights=True')
+            weights = self.weight
+        elif weights is None:
+            raise ValueError('OpenEquivariance requires explicit weights.')
+        weights = jnp.asarray(weights)
+        if weights.dtype != self.dtype:
+            raise TypeError(
+                f'OpenEquivariance weights use {weights.dtype}, expected {self.dtype}; '
+                'mixed dtypes are unsupported.'
+            )
+        if weights.ndim == 1:
+            weights = weights[None, :]
+        if weights.ndim != 2 or weights.shape[-1] != self.weight_numel:
+            raise ValueError(
+                f'Expected weights shape (*, {self.weight_numel}), got {weights.shape}.'
+            )
+        if self.shared_weights:
+            if weights.shape[0] != 1:
+                raise ValueError('Shared OpenEquivariance weights must have shape (1, W).')
+            weights = weights[0]
+        elif weights.shape[0] != batch_size:
+            raise ValueError('Unshared OpenEquivariance weights require one row per item.')
+        if not already_reordered:
+            weights = jnp.take(weights, jnp.asarray(self.weight_permutation), axis=-1)
+        return weights
+
+    def __call__(
+        self,
+        x1,
+        x2,
+        weights=None,
+        edge_index=None,
+        *,
+        weights_are_openeq_order: bool = False,
+    ):
+        x1, x2 = jnp.asarray(x1), jnp.asarray(x2)
+        if x1.dtype != self.dtype or x2.dtype != self.dtype:
+            raise TypeError(
+                'OpenEquivariance inputs must all use the configured dtype '
+                f'{self.dtype}; received {x1.dtype} and {x2.dtype}.'
+            )
+        if self.conv_fusion:
+            if edge_index is None:
+                raise ValueError('OpenEquivariance convolution requires edge_index.')
+            edge_index = jnp.asarray(edge_index)
+            if edge_index.ndim != 2 or edge_index.shape[0] != 2:
+                raise ValueError(
+                    f'edge_index must have shape (2, num_edges); got {edge_index.shape}.'
+                )
+            if x2.shape[0] != edge_index.shape[1]:
+                raise ValueError('Edge attributes and edge_index must have equal edge counts.')
+            if x2.shape[0] == 0:
+                return jnp.zeros((x1.shape[0], self.irreps_out.dim), dtype=self.dtype)
+            reordered = self._weights(
+                weights,
+                edge_index.shape[1],
+                already_reordered=weights_are_openeq_order,
+            )
+            rows = edge_index[1].astype(jnp.int32)
+            cols = edge_index[0].astype(jnp.int32)
+            return self.operator.forward(x1, x2, reordered, rows, cols)
+
+        if x1.shape[0] != x2.shape[0]:
+            raise ValueError('Standalone OpenEquivariance TP inputs need equal batch sizes.')
+        if x1.shape[0] == 0:
+            return jnp.zeros((0, self.irreps_out.dim), dtype=self.dtype)
+        reordered = self._weights(
+            weights, x1.shape[0], already_reordered=weights_are_openeq_order
+        )
+        return self.operator.forward(x1, x2, reordered)
+
+
+def _tensor_product_import_from_torch(cls, torch_module, variables):
+    if getattr(torch_module, 'internal_weights', False) and getattr(
+        torch_module, 'weight_numel', 0
+    ):
+        value = torch_module.weight.detach().cpu().numpy()
+        variables['weight'] = jnp.asarray(value.reshape(1, -1))
+    return variables
+
+
+TensorProduct.import_from_torch = classmethod(_tensor_product_import_from_torch)

--- a/mace_jax/cli/mace_jax_from_torch.py
+++ b/mace_jax/cli/mace_jax_from_torch.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.modules.wrapper_ops import CuEquivarianceConfig, EquivarianceConfig
 from mace_jax.nnx_utils import state_to_pure_dict
 
 warnings.filterwarnings(
@@ -32,6 +32,8 @@ from mace_jax.tools.model_builder import (
     _build_jax_model,
     _prepare_template_data,
 )
+
+import torch
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import torch
@@ -133,6 +135,7 @@ def convert_model(
     torch_model,
     config: dict[str, Any],
     *,
+    equivariance_config: EquivarianceConfig | dict[str, object] | None = None,
     cueq_config: CuEquivarianceConfig | None = None,
 ):
     try:
@@ -143,20 +146,12 @@ def convert_model(
         ) from exc
     _maybe_update_hidden_irreps_from_torch(torch_model, config)
 
-    try:
-        jax_model = _build_jax_model(
-            config,
-            cueq_config=cueq_config,
-            rngs=nnx.Rngs(0),
-        )
-    except TypeError as exc:
-        if 'cueq_config' in str(exc):
-            jax_model = _build_jax_model(
-                config,
-                rngs=nnx.Rngs(0),
-            )
-        else:
-            raise
+    jax_model = _build_jax_model(
+        config,
+        equivariance_config=equivariance_config,
+        cueq_config=cueq_config,
+        rngs=nnx.Rngs(0),
+    )
     template_data = _prepare_template_data(config)
     graphdef, state = nnx.split(jax_model)
     import_from_torch(jax_model, torch_model, state)
@@ -235,7 +230,7 @@ def main():
     config['torch_model_class'] = torch_model.__class__.__name__
 
     _, state, _ = convert_model(torch_model, config)
-    variables = state_to_pure_dict(state)
+    variables = state_to_serializable_dict(state)
 
     params_bytes = serialization.to_bytes(variables)
     output_path.write_bytes(params_bytes)

--- a/mace_jax/cli/mace_jax_train.py
+++ b/mace_jax/cli/mace_jax_train.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import time
 import uuid
+import warnings
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -28,7 +29,11 @@ import optax
 
 import mace_jax
 from mace_jax import modules, tools
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig,
+    EquivarianceConfig,
+    OpenEquivarianceConfig,
+)
 from mace_jax.tools import gin_datasets, gin_functions, gin_model
 from mace_jax.tools.arg_parser import build_cli_arg_parser
 from mace_jax.tools.train import SWAConfig
@@ -588,15 +593,62 @@ def _apply_run_options(args: argparse.Namespace) -> None:
     if args.debug is not None:
         gin.bind_parameter('mace_jax.tools.gin_functions.flags.debug', args.debug)
     _bind_if_not_none('mace_jax.tools.gin_functions.flags.device', args.device)
+    layout_aliases = {
+        '--cueq-layout': args.cueq_layout,
+        '--openeq-layout': args.openeq_layout,
+    }
+    selected_layouts = {
+        value
+        for value in (args.equivariance_layout, *layout_aliases.values())
+        if value is not None
+    }
+    if len(selected_layouts) > 1:
+        raise ValueError(
+            'Conflicting equivariance layouts were supplied through backend and '
+            'model-wide flags.'
+        )
+    for flag, value in layout_aliases.items():
+        if value is not None:
+            warnings.warn(
+                f'{flag} is deprecated; use --equivariance-layout.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+    layout = next(iter(selected_layouts), None)
+    openeq_override = any(
+        value is not None
+        for value in (
+            args.openeq_optimize_all,
+            args.openeq_conv_fusion,
+            args.openeq_group,
+        )
+    )
+    openeq_config = None
+    if getattr(args, 'enable_openeq', False) or openeq_override:
+        enabled = bool(getattr(args, 'enable_openeq', False))
+        openeq_config = OpenEquivarianceConfig(
+            enabled=enabled,
+            optimize_all=(
+                args.openeq_optimize_all
+                if args.openeq_optimize_all is not None
+                else enabled
+            ),
+            conv_fusion=(
+                args.openeq_conv_fusion
+                if args.openeq_conv_fusion is not None
+                else enabled
+            ),
+            group=args.openeq_group or 'O3_e3nn',
+        )
     cueq_override = any(
         value is not None
         for value in (
             args.cueq_optimize_all,
             args.cueq_conv_fusion,
-            args.cueq_layout,
             args.cueq_group,
         )
     )
+    cueq_config = None
     if getattr(args, 'enable_cueq', False) or getattr(args, 'only_cueq', False):
         enable_cueq = getattr(args, 'enable_cueq', False)
         only_cueq = getattr(args, 'only_cueq', False)
@@ -610,13 +662,6 @@ def _apply_run_options(args: argparse.Namespace) -> None:
             want_cuda = bool(gpu_count and gpu_count > 0)
         cueq_config = CuEquivarianceConfig(
             enabled=enable_cueq,
-            layout=(
-                args.cueq_layout
-                if args.cueq_layout is not None
-                else 'ir_mul'
-                if only_cueq
-                else 'mul_ir'
-            ),
             group=(
                 args.cueq_group
                 if args.cueq_group is not None
@@ -631,27 +676,31 @@ def _apply_run_options(args: argparse.Namespace) -> None:
                 else want_cuda
             ),
         )
-        gin.bind_parameter('mace_jax.tools.gin_model.model.cueq_config', cueq_config)
     if (
         cueq_override
         and not getattr(args, 'enable_cueq', False)
         and not getattr(args, 'only_cueq', False)
     ):
-        gin.bind_parameter(
-            'mace_jax.tools.gin_model.model.cueq_config', CuEquivarianceConfig
+        cueq_config = CuEquivarianceConfig(
+            optimize_all=bool(args.cueq_optimize_all),
+            conv_fusion=bool(args.cueq_conv_fusion),
+            group=args.cueq_group or 'O3',
         )
-        if args.cueq_optimize_all is not None:
-            gin.bind_parameter(
-                'CuEquivarianceConfig.optimize_all', args.cueq_optimize_all
+    if cueq_config is not None or openeq_config is not None or layout is not None:
+        if layout is None:
+            layout = (
+                'ir_mul'
+                if getattr(args, 'only_cueq', False)
+                else 'mul_ir'
             )
-        if args.cueq_conv_fusion is not None:
-            gin.bind_parameter(
-                'CuEquivarianceConfig.conv_fusion', args.cueq_conv_fusion
-            )
-        if args.cueq_layout is not None:
-            gin.bind_parameter('CuEquivarianceConfig.layout', args.cueq_layout)
-        if args.cueq_group is not None:
-            gin.bind_parameter('CuEquivarianceConfig.group', args.cueq_group)
+        gin.bind_parameter(
+            'mace_jax.tools.gin_model.model.equivariance_config',
+            EquivarianceConfig(
+                layout=layout,
+                cueq_config=cueq_config,
+                openeq_config=openeq_config,
+            ),
+        )
     if getattr(args, 'distributed', False):
         gin.bind_parameter('mace_jax.tools.gin_functions.flags.distributed', True)
     _bind_if_not_none(

--- a/mace_jax/modules/blocks.py
+++ b/mace_jax/modules/blocks.py
@@ -13,7 +13,7 @@ from mace_jax.adapters.nnx.torch import (
     nxx_register_module,
 )
 from mace_jax.modules.wrapper_ops import (
-    CuEquivarianceConfig,
+    EquivarianceConfig,
     FullyConnectedTensorProduct,
     Linear,
     SymmetricContractionWrapper,
@@ -42,23 +42,23 @@ class LinearNodeEmbeddingBlock(nnx.Module):
 
     irreps_in: Irreps
     irreps_out: Irreps
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
         irreps_in: Irreps,
         irreps_out: Irreps,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
         self.irreps_in = Irreps(irreps_in)
         self.irreps_out = Irreps(irreps_out)
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.linear = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -68,7 +68,7 @@ class LinearNodeEmbeddingBlock(nnx.Module):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(irreps_in={self.irreps_in}, '
-            f'irreps_out={self.irreps_out}, cueq_config={self.cueq_config})'
+            f'irreps_out={self.irreps_out}, equivariance_config={self.equivariance_config})'
         )
 
 
@@ -79,23 +79,23 @@ class LinearReadoutBlock(nnx.Module):
 
     irreps_in: Irreps
     irrep_out: Irreps = Irreps('0e')
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
         irreps_in: Irreps,
         irrep_out: Irreps = Irreps('0e'),
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
         self.irreps_in = Irreps(irreps_in)
         self.irrep_out = Irreps(irrep_out)
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.linear = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irrep_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -110,7 +110,7 @@ class LinearReadoutBlock(nnx.Module):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}(irreps_in={self.irreps_in}, '
-            f'irrep_out={self.irrep_out}, cueq_config={self.cueq_config})'
+            f'irrep_out={self.irrep_out}, equivariance_config={self.equivariance_config})'
         )
 
 
@@ -124,7 +124,7 @@ class NonLinearReadoutBlock(nnx.Module):
     gate: Callable | None
     irrep_out: Irreps = Irreps('0e')
     num_heads: int = 1
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -133,7 +133,7 @@ class NonLinearReadoutBlock(nnx.Module):
         gate: Callable | None,
         irrep_out: Irreps = Irreps('0e'),
         num_heads: int = 1,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -142,12 +142,12 @@ class NonLinearReadoutBlock(nnx.Module):
         self.gate = gate
         self.irrep_out = Irreps(irrep_out)
         self.num_heads = num_heads
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.hidden_irreps = self.MLP_irreps
         self.linear_1 = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.non_linearity = nn.Activation(
@@ -157,7 +157,7 @@ class NonLinearReadoutBlock(nnx.Module):
         self.linear_2 = Linear(
             irreps_in=self.hidden_irreps,
             irreps_out=self.irrep_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -182,7 +182,7 @@ class NonLinearBiasReadoutBlock(nnx.Module):
     gate: Callable | None
     irrep_out: Irreps = Irreps('0e')
     num_heads: int = 1
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -191,7 +191,7 @@ class NonLinearBiasReadoutBlock(nnx.Module):
         gate: Callable | None,
         irrep_out: Irreps = Irreps('0e'),
         num_heads: int = 1,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -200,12 +200,12 @@ class NonLinearBiasReadoutBlock(nnx.Module):
         self.gate = gate
         self.irrep_out = Irreps(irrep_out)
         self.num_heads = num_heads
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.hidden_irreps = self.MLP_irreps
         self.linear_1 = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.non_linearity_1 = nn.Activation(
@@ -215,7 +215,7 @@ class NonLinearBiasReadoutBlock(nnx.Module):
         self.linear_mid = Linear(
             irreps_in=self.hidden_irreps,
             irreps_out=self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.non_linearity_2 = nn.Activation(
@@ -225,7 +225,7 @@ class NonLinearBiasReadoutBlock(nnx.Module):
         self.linear_2 = Linear(
             irreps_in=self.hidden_irreps,
             irreps_out=self.irrep_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -248,19 +248,19 @@ class LinearDipoleReadoutBlock(nnx.Module):
 
     irreps_in: Irreps
     dipole_only: bool = False
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
         irreps_in: Irreps,
         dipole_only: bool = False,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
         self.irreps_in = Irreps(irreps_in)
         self.dipole_only = dipole_only
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         if self.dipole_only:
             self.irreps_out = Irreps('1x1o')
         else:
@@ -269,7 +269,7 @@ class LinearDipoleReadoutBlock(nnx.Module):
         self.linear = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -286,7 +286,7 @@ class NonLinearDipoleReadoutBlock(nnx.Module):
     MLP_irreps: Irreps
     gate: Callable
     dipole_only: bool = False
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -294,7 +294,7 @@ class NonLinearDipoleReadoutBlock(nnx.Module):
         MLP_irreps: Irreps,
         gate: Callable,
         dipole_only: bool = False,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -302,7 +302,7 @@ class NonLinearDipoleReadoutBlock(nnx.Module):
         self.MLP_irreps = Irreps(MLP_irreps)
         self.gate = gate
         self.dipole_only = dipole_only
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.hidden_irreps = self.MLP_irreps
         if self.dipole_only:
             self.irreps_out = Irreps('1x1o')
@@ -337,13 +337,13 @@ class NonLinearDipoleReadoutBlock(nnx.Module):
         self.linear_1 = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irreps_nonlin,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.linear_2 = Linear(
             irreps_in=self.hidden_irreps,
             irreps_out=self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -359,19 +359,19 @@ class LinearDipolePolarReadoutBlock(nnx.Module):
 
     irreps_in: Irreps
     use_polarizability: bool = True
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
         irreps_in: Irreps,
         use_polarizability: bool = True,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
         self.irreps_in = Irreps(irreps_in)
         self.use_polarizability = use_polarizability
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         if not self.use_polarizability:
             raise ValueError(
                 'LinearDipolePolarReadoutBlock requires use_polarizability=True.'
@@ -380,7 +380,7 @@ class LinearDipolePolarReadoutBlock(nnx.Module):
         self.linear = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -397,7 +397,7 @@ class NonLinearDipolePolarReadoutBlock(nnx.Module):
     MLP_irreps: Irreps
     gate: Callable
     use_polarizability: bool = True
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -405,7 +405,7 @@ class NonLinearDipolePolarReadoutBlock(nnx.Module):
         MLP_irreps: Irreps,
         gate: Callable,
         use_polarizability: bool = True,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -413,7 +413,7 @@ class NonLinearDipolePolarReadoutBlock(nnx.Module):
         self.MLP_irreps = Irreps(MLP_irreps)
         self.gate = gate
         self.use_polarizability = use_polarizability
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self.hidden_irreps = self.MLP_irreps
         if not self.use_polarizability:
             raise ValueError(
@@ -449,13 +449,13 @@ class NonLinearDipolePolarReadoutBlock(nnx.Module):
         self.linear_1 = Linear(
             irreps_in=self.irreps_in,
             irreps_out=self.irreps_nonlin,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.linear_2 = Linear(
             irreps_in=self.hidden_irreps,
             irreps_out=self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -592,7 +592,7 @@ class EquivariantProductBasisBlock(nnx.Module):
     num_elements: int | None = None
     use_agnostic_product: bool = False
     use_reduced_cg: bool | None = None
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -603,7 +603,7 @@ class EquivariantProductBasisBlock(nnx.Module):
         num_elements: int | None = None,
         use_agnostic_product: bool = False,
         use_reduced_cg: bool | None = None,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -614,7 +614,7 @@ class EquivariantProductBasisBlock(nnx.Module):
         self.num_elements = num_elements
         self.use_agnostic_product = use_agnostic_product
         self.use_reduced_cg = use_reduced_cg
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
 
         num_elements_local = self.num_elements
         if self.use_agnostic_product:
@@ -626,7 +626,7 @@ class EquivariantProductBasisBlock(nnx.Module):
             correlation=self.correlation,
             num_elements=num_elements_local,
             use_reduced_cg=self.use_reduced_cg,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -635,7 +635,7 @@ class EquivariantProductBasisBlock(nnx.Module):
             irreps_out=self.target_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -651,10 +651,11 @@ class EquivariantProductBasisBlock(nnx.Module):
             node_attrs_index = None
 
         use_cueq = False
-        layout_str = getattr(self.cueq_config, 'layout_str', 'mul_ir')
-        if self.cueq_config is not None:
-            if self.cueq_config.enabled and (
-                self.cueq_config.optimize_all or self.cueq_config.optimize_symmetric
+        layout_str = getattr(self.equivariance_config, 'layout_str', 'mul_ir')
+        cueq_config = getattr(self.equivariance_config, 'cueq_config', None)
+        if cueq_config is not None:
+            if cueq_config.enabled and (
+                cueq_config.optimize_all or cueq_config.optimize_symmetric
             ):
                 use_cueq = True
 
@@ -693,7 +694,7 @@ class InteractionBlock(nnx.Module, metaclass=abc.ABCMeta):
     avg_num_neighbors: float
     edge_irreps: Irreps | None = None
     radial_MLP: Sequence[int] | None = None
-    cueq_config: CuEquivarianceConfig | None = None
+    equivariance_config: EquivarianceConfig | None = None
 
     def __init__(
         self,
@@ -706,7 +707,7 @@ class InteractionBlock(nnx.Module, metaclass=abc.ABCMeta):
         avg_num_neighbors: float,
         edge_irreps: Irreps | None = None,
         radial_MLP: Sequence[int] | None = None,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         *,
         rngs: nnx.Rngs,
     ) -> None:
@@ -717,7 +718,7 @@ class InteractionBlock(nnx.Module, metaclass=abc.ABCMeta):
         self.target_irreps = Irreps(target_irreps)
         self.hidden_irreps = Irreps(hidden_irreps)
         self.avg_num_neighbors = avg_num_neighbors
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
 
         if radial_MLP is not None:
             self.radial_MLP = list(radial_MLP)
@@ -729,8 +730,17 @@ class InteractionBlock(nnx.Module, metaclass=abc.ABCMeta):
         else:
             self.edge_irreps = Irreps(self.node_feats_irreps)
 
-        if self.cueq_config and getattr(self.cueq_config, 'conv_fusion', None):
-            self.conv_fusion = self.cueq_config.conv_fusion
+        openeq_config = (
+            getattr(self.equivariance_config, 'openeq_config', None)
+            if self.equivariance_config is not None
+            else None
+        )
+        cueq_config = getattr(self.equivariance_config, 'cueq_config', None)
+        if (cueq_config and getattr(cueq_config, 'conv_fusion', False)) or (
+            openeq_config
+            and getattr(openeq_config, 'channelwise_fusion', False)
+        ):
+            self.conv_fusion = True
 
         self._setup(rngs)
 
@@ -744,6 +754,40 @@ class InteractionBlock(nnx.Module, metaclass=abc.ABCMeta):
         n_real: int | None = None,
     ) -> jnp.ndarray:
         return tensor[:n_real] if n_real is not None else tensor
+
+    def _fused_tensor_product(
+        self,
+        node_feats: jnp.ndarray,
+        edge_attrs: jnp.ndarray,
+        tp_weights: jnp.ndarray,
+        edge_index: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Run a fused TP with backend-ordered projected weights when required."""
+        if getattr(self.conv_tp, 'expects_projected_weights', False):
+            return self.conv_tp(
+                node_feats,
+                edge_attrs,
+                tp_weights,
+                edge_index,
+                weights_are_openeq_order=True,
+            )
+        return self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+
+    def _standalone_tensor_product(
+        self,
+        node_feats: jnp.ndarray,
+        edge_attrs: jnp.ndarray,
+        tp_weights: jnp.ndarray,
+    ) -> jnp.ndarray:
+        """Run an edge TP whose radial projection may already be backend ordered."""
+        if getattr(self.conv_tp, 'expects_projected_weights', False):
+            return self.conv_tp(
+                node_feats,
+                edge_attrs,
+                tp_weights,
+                weights_are_openeq_order=True,
+            )
+        return self.conv_tp(node_feats, edge_attrs, tp_weights)
 
     @abc.abstractmethod
     def __call__(
@@ -767,7 +811,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -784,7 +828,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -794,6 +838,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             + list(self.radial_MLP)
             + [self.conv_tp.weight_numel],
             act=jax.nn.silu,
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -804,7 +849,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -813,10 +858,10 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             self.irreps_out,
             self.node_attrs_irreps,
             self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
     def __call__(
         self,
@@ -839,9 +884,13 @@ class RealAgnosticInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(node_feats[edge_index[0]], edge_attrs, tp_weights)
+            mji = self._standalone_tensor_product(
+                node_feats[edge_index[0]], edge_attrs, tp_weights
+            )
             message = scatter_sum(
                 src=mji, index=edge_index[1], dim=0, dim_size=node_feats.shape[0]
             )
@@ -868,7 +917,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -885,7 +934,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -895,6 +944,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             + list(self.radial_MLP)
             + [self.conv_tp.weight_numel],
             act=jax.nn.silu,
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -905,7 +955,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -914,10 +964,10 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             self.node_feats_irreps,
             self.node_attrs_irreps,
             self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
     def __call__(
         self,
@@ -943,9 +993,13 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(node_feats[edge_index[0]], edge_attrs, tp_weights)
+            mji = self._standalone_tensor_product(
+                node_feats[edge_index[0]], edge_attrs, tp_weights
+            )
             message = scatter_sum(
                 src=mji,
                 index=edge_index[1],
@@ -975,7 +1029,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -992,7 +1046,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1002,6 +1056,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             + list(self.radial_MLP)
             + [self.conv_tp.weight_numel],
             act=jax.nn.silu,
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -1012,7 +1067,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1021,7 +1076,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             self.irreps_out,
             self.node_attrs_irreps,
             self.irreps_out,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1033,7 +1088,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
         )
 
         # Reshape output
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
     def __call__(
         self,
@@ -1069,9 +1124,13 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(node_feats[edge_index[0]], edge_attrs, tp_weights)
+            mji = self._standalone_tensor_product(
+                node_feats[edge_index[0]], edge_attrs, tp_weights
+            )
             message = scatter_sum(
                 src=mji, index=edge_index[1], dim=0, dim_size=node_feats.shape[0]
             )
@@ -1099,7 +1158,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1116,7 +1175,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1126,6 +1185,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             + list(self.radial_MLP)
             + [self.conv_tp.weight_numel],
             act=jax.nn.silu,
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -1136,7 +1196,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1145,7 +1205,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             self.node_feats_irreps,
             self.node_attrs_irreps,
             self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1157,7 +1217,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
         )
 
         # Reshape output
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
     def __call__(
         self,
@@ -1196,9 +1256,11 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(
+            mji = self._standalone_tensor_product(
                 node_feats[edge_index[0]], edge_attrs, tp_weights
             )  # [n_nodes, irreps]
             message = scatter_sum(
@@ -1229,7 +1291,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1246,7 +1308,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1256,7 +1318,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
             self.node_feats_down_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1268,6 +1330,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
         self.conv_tp_weights = nn.FullyConnectedNet(
             hs=[input_dim] + [256, 256, 256] + [self.conv_tp.weight_numel],
             act=jax.nn.silu,
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -1278,18 +1341,18 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
         # Output reshape
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
         # Skip connection
         self.skip_linear = Linear(
             self.node_feats_irreps,
             self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1326,9 +1389,11 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats_up, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats_up, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(
+            mji = self._standalone_tensor_product(
                 node_feats_up[edge_index[0]], edge_attrs, tp_weights
             )  # [n_nodes, irreps]
             message = scatter_sum(
@@ -1358,7 +1423,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             node_scalar_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.target_embedding = Linear(
@@ -1366,7 +1431,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             node_scalar_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1376,7 +1441,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             self.edge_irreps,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1393,7 +1458,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             instructions=instructions,
             shared_weights=False,
             internal_weights=False,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1403,6 +1468,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             [input_dim + 2 * node_scalar_irreps.dim]
             + self.radial_MLP
             + [self.conv_tp.weight_numel],
+            output_permutation=getattr(self.conv_tp, 'projection_permutation', None),
             rngs=rngs,
         )
 
@@ -1413,12 +1479,12 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         self.skip_tp = Linear(
             self.node_feats_irreps,
             self.hidden_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
         # Reshape
-        self.reshape = reshape_irreps(self.irreps_out, cueq_config=self.cueq_config)
+        self.reshape = reshape_irreps(self.irreps_out, equivariance_config=self.equivariance_config)
 
         # Equivariant non-linearity
         irreps_scalars = Irreps([(mul, ir) for mul, ir in self.irreps_out if ir.l == 0])
@@ -1439,7 +1505,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             self.irreps_nonlin,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1449,7 +1515,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             self.irreps_nonlin,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         self.linear_2 = Linear(
@@ -1457,7 +1523,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             self.irreps_out,
             internal_weights=True,
             shared_weights=True,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -1475,13 +1541,13 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             irreps=self.irreps_nonlin,
             source='ir_mul',
             target='mul_ir',
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
         )
         self.transpose_ir_mul = TransposeIrrepsLayoutWrapper(
             irreps=self.irreps_out,
             source='mul_ir',
             target='ir_mul',
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
         )
 
     def __call__(
@@ -1530,9 +1596,11 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
 
         # Message passing
         if hasattr(self, 'conv_fusion'):
-            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self._fused_tensor_product(
+                node_feats, edge_attrs, tp_weights, edge_index
+            )
         else:
-            mji = self.conv_tp(
+            mji = self._standalone_tensor_product(
                 node_feats[edge_index[0]], edge_attrs, tp_weights
             )  # [n_edges, irreps]
             message = scatter_sum(

--- a/mace_jax/modules/irreps_tools.py
+++ b/mace_jax/modules/irreps_tools.py
@@ -7,7 +7,7 @@
 import jax.numpy as jnp
 from e3nn_jax import Irreps
 
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.modules.wrapper_ops import EquivarianceConfig
 
 
 # Based on mir-group/nequip
@@ -67,10 +67,10 @@ class reshape_irreps:
     def __init__(
         self,
         irreps: Irreps,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
     ):
         self.irreps = Irreps(irreps)
-        self.cueq_config = cueq_config
+        self.equivariance_config = equivariance_config
         self._dims = [ir.dim for _, ir in self.irreps]
         self._muls = [mul for mul, _ in self.irreps]
         self._total_dim = sum(mul * dim for mul, dim in zip(self._muls, self._dims))
@@ -95,14 +95,14 @@ class reshape_irreps:
             field = array[:, ix : ix + mul * dim]
             ix += mul * dim
 
-            if self.cueq_config is not None and self.cueq_config.layout_str == 'ir_mul':
+            if self.equivariance_config is not None and self.equivariance_config.layout_str == 'ir_mul':
                 field = field.reshape(batch, dim, mul)
             else:
                 field = field.reshape(batch, mul, dim)
 
             fields.append(field)
 
-        if self.cueq_config is not None and self.cueq_config.layout_str == 'ir_mul':
+        if self.equivariance_config is not None and self.equivariance_config.layout_str == 'ir_mul':
             return jnp.concatenate(fields, axis=-2)
         return jnp.concatenate(fields, axis=-1)
 

--- a/mace_jax/modules/models.py
+++ b/mace_jax/modules/models.py
@@ -16,6 +16,10 @@ from mace_jax.adapters.e3nn.o3 import SphericalHarmonics
 from mace_jax.adapters.nnx.torch import nxx_auto_import_from_torch
 from mace_jax.modules.embeddings import GenericJointEmbedding
 from mace_jax.modules.radial import ZBLBasis
+from mace_jax.modules.wrapper_ops import (
+    EquivarianceConfig,
+    resolve_equivariance_config,
+)
 from mace_jax.nnx_config import ConfigVar
 from mace_jax.tools.dtype import default_dtype
 from mace_jax.tools.lammps_exchange import forward_exchange as lammps_forward_exchange
@@ -52,6 +56,19 @@ def _apply_lammps_exchange(
     padded = jnp.concatenate((node_feats, pad), axis=0)
     exchanged = lammps_forward_exchange(padded, lammps_class)
     return exchanged
+
+
+def _apply_comm_exchange(
+    node_feats: jnp.ndarray,
+    comm: Any | None,
+) -> jnp.ndarray:
+    """Gather ghost features through an optional deployment communicator."""
+
+    if comm is None:
+        return node_feats
+    if not hasattr(comm, 'gather'):
+        raise AttributeError('Communication interface must implement gather().')
+    return comm.gather(node_feats)
 
 
 def _as_tuple(value: Sequence[int] | int, repeats: int) -> tuple[int, ...]:
@@ -121,6 +138,8 @@ class MACE(nnx.Module):
         radial_MLP: Sequence[int] | None = None,
         radial_type: str = 'bessel',
         heads: Sequence[str] | None = None,
+        use_edge_irreps_first: bool = False,
+        equivariance_config: EquivarianceConfig | dict[str, Any] | None = None,
         cueq_config: dict[str, Any] | None = None,
         embedding_specs: dict[str, Any] | None = None,
         readout_cls: type[NonLinearReadoutBlock] = NonLinearReadoutBlock,
@@ -155,7 +174,10 @@ class MACE(nnx.Module):
         self.radial_MLP = radial_MLP
         self.radial_type = radial_type
         self.heads = heads
-        self.cueq_config = cueq_config
+        self.use_edge_irreps_first = use_edge_irreps_first
+        self.equivariance_config = resolve_equivariance_config(
+            equivariance_config, cueq_config=cueq_config
+        )
         self.embedding_specs = embedding_specs
         self.readout_cls = readout_cls
 
@@ -204,7 +226,7 @@ class MACE(nnx.Module):
         self.node_embedding = LinearNodeEmbeddingBlock(
             irreps_in=node_attr_irreps,
             irreps_out=node_feats_irreps,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
 
@@ -221,7 +243,7 @@ class MACE(nnx.Module):
                 self.embedding_readout = LinearReadoutBlock(
                     node_feats_irreps,
                     Irreps(f'{len(self._heads)}x0e'),
-                    self.cueq_config,
+                    self.equivariance_config,
                     rngs=rngs,
                 )
 
@@ -269,6 +291,11 @@ class MACE(nnx.Module):
             list(self.radial_MLP) if self.radial_MLP is not None else [64, 64, 64]
         )
         self.atomic_energies_fn = AtomicEnergiesBlock(self._atomic_energies, rngs=rngs)
+        edge_irreps_first = None
+        if self.use_edge_irreps_first and self.edge_irreps is not None:
+            edge_irreps_first = Irreps(
+                f'{self.edge_irreps.count(Irrep(0, 1))}x0e'
+            )
 
         interactions: list[InteractionBlock] = []
         products: list[EquivariantProductBasisBlock] = []
@@ -281,9 +308,10 @@ class MACE(nnx.Module):
             edge_feats_irreps=edge_feats_irreps,
             target_irreps=interaction_irreps_first,
             hidden_irreps=hidden_irreps_out,
+            edge_irreps=edge_irreps_first,
             avg_num_neighbors=self.avg_num_neighbors,
             radial_MLP=radial_mlp,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             rngs=rngs,
         )
         interactions.append(interaction_first)
@@ -295,7 +323,7 @@ class MACE(nnx.Module):
             correlation=self._correlation[0],
             num_elements=self.num_elements,
             use_sc=use_sc_first,
-            cueq_config=self.cueq_config,
+            equivariance_config=self.equivariance_config,
             use_reduced_cg=self.use_reduced_cg,
             use_agnostic_product=self.use_agnostic_product,
             rngs=rngs,
@@ -307,7 +335,7 @@ class MACE(nnx.Module):
                 LinearReadoutBlock(
                     hidden_irreps_out,
                     Irreps(f'{len(self._heads)}x0e'),
-                    self.cueq_config,
+                    self.equivariance_config,
                     rngs=rngs,
                 )
             )
@@ -328,7 +356,7 @@ class MACE(nnx.Module):
                 avg_num_neighbors=self.avg_num_neighbors,
                 edge_irreps=self.edge_irreps,
                 radial_MLP=radial_mlp,
-                cueq_config=self.cueq_config,
+                equivariance_config=self.equivariance_config,
                 rngs=rngs,
             )
             interactions.append(interaction)
@@ -339,7 +367,7 @@ class MACE(nnx.Module):
                 correlation=self._correlation[idx + 1],
                 num_elements=self.num_elements,
                 use_sc=True,
-                cueq_config=self.cueq_config,
+                equivariance_config=self.equivariance_config,
                 use_reduced_cg=self.use_reduced_cg,
                 use_agnostic_product=self.use_agnostic_product,
                 rngs=rngs,
@@ -354,7 +382,7 @@ class MACE(nnx.Module):
                         self.gate,
                         Irreps(f'{len(self._heads)}x0e'),
                         len(self._heads),
-                        self.cueq_config,
+                        self.equivariance_config,
                         rngs=rngs,
                     )
                 )
@@ -363,7 +391,7 @@ class MACE(nnx.Module):
                     LinearReadoutBlock(
                         hidden_irreps,
                         Irreps(f'{len(self._heads)}x0e'),
-                        self.cueq_config,
+                        self.equivariance_config,
                         rngs=rngs,
                     )
                 )
@@ -378,6 +406,7 @@ class MACE(nnx.Module):
         *,
         lammps_mliap: bool = False,
         lammps_class: Any | None = None,
+        comm: Any | None = None,
         compute_node_feats: bool = True,
     ) -> dict[str, jnp.ndarray | None]:
         ctx = prepare_graph(
@@ -398,10 +427,11 @@ class MACE(nnx.Module):
             'Agnesi',
             'Soft',
         }
-        if self.cueq_config is not None and getattr(self.cueq_config, 'enabled', False):
+        cueq_config = getattr(self.equivariance_config, 'cueq_config', None)
+        if cueq_config is not None and getattr(cueq_config, 'enabled', False):
             need_node_attrs_index = need_node_attrs_index or bool(
-                getattr(self.cueq_config, 'optimize_all', False)
-                or getattr(self.cueq_config, 'optimize_symmetric', False)
+                getattr(cueq_config, 'optimize_all', False)
+                or getattr(cueq_config, 'optimize_symmetric', False)
             )
         node_attrs_index = data.get('node_attrs_index')
         if node_attrs_index is None:
@@ -485,6 +515,8 @@ class MACE(nnx.Module):
                 node_feats = _apply_lammps_exchange(
                     node_feats, lammps_class, lammps_natoms
                 )
+            elif comm is not None and idx > 0:
+                node_feats = _apply_comm_exchange(node_feats, comm)
 
             node_attrs_slice = node_attrs_full
             node_attrs_index_slice = node_attrs_index_full
@@ -579,6 +611,7 @@ class ScaleShiftMACE(MACE):
         *,
         lammps_mliap: bool = False,
         lammps_class: Any | None = None,
+        comm: Any | None = None,
         compute_node_feats: bool = True,
     ) -> dict[str, jnp.ndarray | None]:
         ctx = prepare_graph(
@@ -591,7 +624,6 @@ class ScaleShiftMACE(MACE):
         interaction_kwargs = ctx.interaction_kwargs
         lammps_class = interaction_kwargs.lammps_class
         lammps_natoms = interaction_kwargs.lammps_natoms
-        n_real = int(num_atoms_arange.shape[0])
         if lammps_class is not None:
             n_real = int(lammps_natoms[0])
         node_attrs = data['node_attrs']
@@ -599,10 +631,11 @@ class ScaleShiftMACE(MACE):
             'Agnesi',
             'Soft',
         }
-        if self.cueq_config is not None and getattr(self.cueq_config, 'enabled', False):
+        cueq_config = getattr(self.equivariance_config, 'cueq_config', None)
+        if cueq_config is not None and getattr(cueq_config, 'enabled', False):
             need_node_attrs_index = need_node_attrs_index or bool(
-                getattr(self.cueq_config, 'optimize_all', False)
-                or getattr(self.cueq_config, 'optimize_symmetric', False)
+                getattr(cueq_config, 'optimize_all', False)
+                or getattr(cueq_config, 'optimize_symmetric', False)
             )
         node_attrs_index = data.get('node_attrs_index')
         if node_attrs_index is None:
@@ -676,6 +709,8 @@ class ScaleShiftMACE(MACE):
                 node_feats = _apply_lammps_exchange(
                     node_feats, lammps_class, lammps_natoms
                 )
+            elif comm is not None and idx > 0:
+                node_feats = _apply_comm_exchange(node_feats, comm)
 
             node_attrs_slice = node_attrs_full
             node_attrs_index_slice = node_attrs_index_full

--- a/mace_jax/modules/radial.py
+++ b/mace_jax/modules/radial.py
@@ -434,8 +434,17 @@ class SoftTransform(nnx.Module):
 class _RadialSequential(nnx.Module):
     channels: Sequence[int]
 
-    def __init__(self, channels: Sequence[int], *, rngs: nnx.Rngs) -> None:
+    def __init__(
+        self,
+        channels: Sequence[int],
+        output_permutation: Sequence[int] | None = None,
+        *,
+        rngs: nnx.Rngs,
+    ) -> None:
         self.channels = tuple(channels)
+        self.output_permutation = (
+            tuple(output_permutation) if output_permutation is not None else None
+        )
         if len(self.channels) < 2:
             raise ValueError('channels must have length >= 2 for RadialMLP')
 
@@ -471,13 +480,25 @@ class _RadialSequential(nnx.Module):
 
     def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
         x = inputs
-        for kind, key in self._layer_order:
+        for order_index, (kind, key) in enumerate(self._layer_order):
             if kind == 'act':
                 x = jax.nn.silu(x)
                 continue
             if key is None:
                 raise ValueError('Missing layer key for radial sequential block')
-            x = self.layers[key](x)
+            layer = self.layers[key]
+            is_last = order_index == len(self._layer_order) - 1
+            if is_last and self.output_permutation is not None:
+                kernel = jnp.take(
+                    layer.kernel, jnp.asarray(self.output_permutation), axis=-1
+                )
+                x = x @ kernel
+                if layer.bias is not None:
+                    x = x + jnp.take(
+                        layer.bias, jnp.asarray(self.output_permutation), axis=-1
+                    )
+            else:
+                x = layer(x)
         return x
 
 
@@ -487,9 +508,20 @@ class RadialMLP(nnx.Module):
 
     channels: Sequence[int]
 
-    def __init__(self, channels: Sequence[int], *, rngs: nnx.Rngs) -> None:
+    def __init__(
+        self,
+        channels: Sequence[int],
+        output_permutation: Sequence[int] | None = None,
+        *,
+        rngs: nnx.Rngs,
+    ) -> None:
         self.channels = tuple(channels)
-        self.net = _RadialSequential(self.channels, rngs=rngs)
+        self.output_permutation = (
+            tuple(output_permutation) if output_permutation is not None else None
+        )
+        self.net = _RadialSequential(
+            self.channels, output_permutation=self.output_permutation, rngs=rngs
+        )
 
     def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
         return self.net(inputs)

--- a/mace_jax/modules/utils.py
+++ b/mace_jax/modules/utils.py
@@ -415,6 +415,30 @@ def add_output_interface(cls=None):
 
             energy_arr = raw_out['energy'] if isinstance(raw_out, dict) else raw_out
 
+            # The energy-only path already has every model output in raw_out.
+            # Calling get_outputs would evaluate _energy_fn a second time only
+            # to recover the same energy. Pure computations normally hide this
+            # duplication through dead-code elimination, while side-effectful
+            # feature communication must execute both evaluations.
+            try:
+                energy_only = not bool(compute_force) and not bool(compute_stress)
+            except TracerBoolConversionError:
+                energy_only = False
+            if energy_only:
+                result = (
+                    dict(raw_out)
+                    if isinstance(raw_out, dict)
+                    else {'energy': energy_arr}
+                )
+                result.update(
+                    {
+                        'energy': jnp.atleast_1d(jnp.asarray(energy_arr)),
+                        'forces': None,
+                        'stress': None,
+                    }
+                )
+                return result
+
             def energy_fn(positions, shifts=None):
                 # Replace the positions in `data` with `pos` before recomputing
                 new_data = dict(data)

--- a/mace_jax/modules/wrapper_ops.py
+++ b/mace_jax/modules/wrapper_ops.py
@@ -3,6 +3,7 @@ Wrapper class for o3.Linear that optionally uses cuet.Linear
 """
 
 import dataclasses
+import warnings
 from typing import Optional
 
 import cuequivariance as cue
@@ -61,12 +62,71 @@ def _validate_cue_group(group_value: object | None, *, context: str) -> None:
 
 
 @dataclasses.dataclass
+class OpenEquivarianceConfig:
+    """Configuration for the supported OpenEquivariance JAX operations.
+
+    Fully connected tensor products are intentionally unavailable.  The
+    OpenEquivariance 0.6.8 backward kernel is order-dependent when multiple
+    FCTP problems execute in one process and can silently corrupt force
+    derivatives.  Keep ``optimize_fctp`` in the serialized schema so affected
+    bundles fail explicitly instead of changing their meaning while loading.
+    """
+
+    enabled: bool = False
+    group: str = 'O3_e3nn'
+    optimize_all: bool = False
+    optimize_linear: bool = False
+    optimize_channelwise: bool = False
+    optimize_symmetric: bool = False
+    optimize_fctp: bool = False
+    conv_fusion: bool = False
+
+    def __post_init__(self) -> None:
+        unsupported = []
+        if self.optimize_linear:
+            unsupported.append('optimize_linear')
+        if self.optimize_symmetric:
+            unsupported.append('optimize_symmetric')
+        if self.optimize_fctp:
+            unsupported.append('optimize_fctp (OpenEquivariance 0.6.8 backward '
+                               'is not safe for general FCTP execution)')
+        if unsupported:
+            raise ValueError(
+                'OpenEquivariance does not accelerate these operations: '
+                f"{', '.join(unsupported)}."
+            )
+        if self.group != 'O3_e3nn':
+            raise ValueError(
+                "OpenEquivariance v1 requires group='O3_e3nn'; "
+                f'received {self.group!r}.'
+            )
+
+    @property
+    def channelwise_fusion(self) -> bool:
+        return bool(
+            self.enabled
+            and self.conv_fusion
+            and (self.optimize_all or self.optimize_channelwise)
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'enabled': bool(self.enabled),
+            'group': 'O3_e3nn',
+            'optimize_all': bool(self.optimize_all),
+            'optimize_linear': bool(self.optimize_linear),
+            'optimize_channelwise': bool(self.optimize_channelwise),
+            'optimize_symmetric': bool(self.optimize_symmetric),
+            'optimize_fctp': bool(self.optimize_fctp),
+            'conv_fusion': bool(self.conv_fusion),
+        }
+
+
+@dataclasses.dataclass
 class CuEquivarianceConfig:
     """Configuration for cuequivariance acceleration"""
 
     enabled: bool = False
-    layout: str = 'mul_ir'  # One of: mul_ir, ir_mul
-    layout_str: str = 'mul_ir'
     group: str = 'O3'
     optimize_all: bool = False  # Set to True to enable all optimizations
     optimize_linear: bool = False
@@ -77,11 +137,111 @@ class CuEquivarianceConfig:
 
     def __post_init__(self):
         if self.enabled:
-            self.layout_str = self.layout
-            self.layout = getattr(cue, self.layout)
             self.group = (
                 O3_e3nn if self.group == 'O3_e3nn' else getattr(cue, self.group)
             )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable bundle representation without backend class objects."""
+        return {
+            'enabled': bool(self.enabled),
+            'group': _group_name(self.group) or 'O3',
+            'optimize_all': bool(self.optimize_all),
+            'optimize_linear': bool(self.optimize_linear),
+            'optimize_channelwise': bool(self.optimize_channelwise),
+            'optimize_symmetric': bool(self.optimize_symmetric),
+            'optimize_fctp': bool(self.optimize_fctp),
+            'conv_fusion': bool(self.conv_fusion),
+        }
+
+
+@dataclasses.dataclass
+class EquivarianceConfig:
+    """Backend-neutral equivariance acceleration configuration."""
+
+    layout: str = 'mul_ir'
+    cueq_config: CuEquivarianceConfig | dict[str, object] | None = None
+    openeq_config: OpenEquivarianceConfig | dict[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if self.layout not in {'mul_ir', 'ir_mul'}:
+            raise ValueError(
+                "layout must be either 'mul_ir' or 'ir_mul'; "
+                f'received {self.layout!r}.'
+            )
+        if isinstance(self.cueq_config, dict):
+            self.cueq_config = CuEquivarianceConfig(**self.cueq_config)
+        if isinstance(self.openeq_config, dict):
+            self.openeq_config = OpenEquivarianceConfig(**self.openeq_config)
+        if self.openeq_config is not None and self.openeq_config.channelwise_fusion:
+            cueq = self.cueq_config
+            cue_channelwise = cueq is not None and (
+                cueq.conv_fusion
+                or (cueq.enabled and (cueq.optimize_all or cueq.optimize_channelwise))
+            )
+            if cue_channelwise:
+                raise ValueError(
+                    'OpenEquivariance and cuEquivariance cannot both be selected '
+                    'for the channel-wise convolution.'
+                )
+
+    @property
+    def layout_str(self) -> str:
+        """Compatibility spelling used by existing layout-aware modules."""
+        return self.layout
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the canonical, backend-neutral bundle representation."""
+        return {
+            'layout': self.layout,
+            'cueq_config': (
+                self.cueq_config.to_dict() if self.cueq_config is not None else None
+            ),
+            'openeq_config': (
+                self.openeq_config.to_dict() if self.openeq_config is not None else None
+            ),
+        }
+
+
+def resolve_equivariance_config(
+    equivariance_config: EquivarianceConfig | dict[str, object] | None = None,
+    *,
+    cueq_config: CuEquivarianceConfig | dict[str, object] | None = None,
+) -> EquivarianceConfig | None:
+    """Resolve the canonical config and migrate the deprecated model argument."""
+    if equivariance_config is not None and cueq_config is not None:
+        raise ValueError(
+            'Specify only equivariance_config; cueq_config is a deprecated alias.'
+        )
+    if equivariance_config is not None:
+        if isinstance(equivariance_config, EquivarianceConfig):
+            return equivariance_config
+        return EquivarianceConfig(**equivariance_config)
+    if cueq_config is None:
+        return None
+
+    warnings.warn(
+        'cueq_config is deprecated; pass equivariance_config instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    if isinstance(cueq_config, CuEquivarianceConfig):
+        return EquivarianceConfig(cueq_config=cueq_config)
+
+    legacy = dict(cueq_config)
+    nested_openeq = legacy.pop('openeq_config', None)
+    layout = legacy.pop('layout', None)
+    layout_str = legacy.pop('layout_str', None)
+    if layout is not None and layout_str is not None and layout != layout_str:
+        raise ValueError(
+            'Legacy cueq_config has conflicting layout and layout_str values.'
+        )
+    layout = str(layout if layout is not None else layout_str or 'mul_ir')
+    return EquivarianceConfig(
+        layout=layout,
+        cueq_config=CuEquivarianceConfig(**legacy),
+        openeq_config=nested_openeq,
+    )
 
 
 class Linear:
@@ -93,15 +253,18 @@ class Linear:
         irreps_out: Irreps,
         shared_weights: bool = True,
         internal_weights: bool = True,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
         rngs: nnx.Rngs | None = None,
     ):
+        cueq_config = (
+            equivariance_config.cueq_config if equivariance_config is not None else None
+        )
         group_value = getattr(cueq_config, 'group', None) if cueq_config else None
         _validate_cue_group(group_value, context='Linear')
         group = _resolve_cue_group(cueq_config) if cueq_config else None
         layout = (
-            getattr(cueq_config, 'layout', 'mul_ir')
-            if cueq_config is not None
+            equivariance_config.layout
+            if equivariance_config is not None
             else 'mul_ir'
         )
 
@@ -132,10 +295,41 @@ class TensorProduct:
         instructions=None,
         shared_weights: bool = False,
         internal_weights: bool = False,
-        cueq_config=None,
+        equivariance_config: EquivarianceConfig | None = None,
         rngs: nnx.Rngs | None = None,
     ):
         conv_fusion = False
+        cueq_config = (
+            equivariance_config.cueq_config if equivariance_config is not None else None
+        )
+        openeq_config = (
+            equivariance_config.openeq_config
+            if equivariance_config is not None
+            else None
+        )
+        use_openeq = bool(
+            openeq_config is not None
+            and openeq_config.enabled
+            and (openeq_config.optimize_all or openeq_config.optimize_channelwise)
+        )
+        if use_openeq:
+            # Keep this import lazy: OpenEquivariance is an optional CUDA backend.
+            from mace_jax.adapters.openequivariance import (
+                TensorProduct as OpenEqTensorProduct,
+            )
+
+            return OpenEqTensorProduct(
+                irreps_in1,
+                irreps_in2,
+                irreps_out,
+                instructions=instructions,
+                shared_weights=shared_weights,
+                internal_weights=internal_weights,
+                conv_fusion=openeq_config.conv_fusion,
+                layout=equivariance_config.layout,
+                group=openeq_config.group,
+                rngs=rngs,
+            )
         group_value = getattr(cueq_config, 'group', None) if cueq_config else None
         _validate_cue_group(group_value, context='TensorProduct')
         group = _resolve_cue_group(cueq_config) if cueq_config else None
@@ -165,7 +359,7 @@ def FullyConnectedTensorProduct(
     irreps_out: Irreps,
     shared_weights: bool = True,
     internal_weights: bool = True,
-    cueq_config: CuEquivarianceConfig | None = None,
+    equivariance_config: EquivarianceConfig | None = None,
     rngs: nnx.Rngs | None = None,
 ):
     """
@@ -173,6 +367,9 @@ def FullyConnectedTensorProduct(
     When CuEquivariance acceleration is requested, this raises since a JAX binding
     is not yet available; otherwise defaults to the e3nn_jax implementation.
     """
+    cueq_config = (
+        equivariance_config.cueq_config if equivariance_config is not None else None
+    )
     use_cue = (
         cueq_config is not None
         and getattr(cueq_config, 'enabled', False)
@@ -210,7 +407,7 @@ def SymmetricContractionWrapper(
     irreps_out: Irreps,
     correlation: int,
     num_elements: int | None = None,
-    cueq_config: Optional['CuEquivarianceConfig'] = None,
+    equivariance_config: Optional['EquivarianceConfig'] = None,
     use_reduced_cg: bool = True,
     rngs: nnx.Rngs | None = None,
 ):
@@ -218,22 +415,28 @@ def SymmetricContractionWrapper(
     JAX implementation of SymmetricContraction powered by cuequivariance-jax.
     """
 
+    cueq_config = (
+        equivariance_config.cueq_config if equivariance_config is not None else None
+    )
     use_cue = cueq_config is not None and getattr(cueq_config, 'enabled', False)
 
     group_value = getattr(cueq_config, 'group', None) if cueq_config else None
     if cueq_config is not None:
         _validate_cue_group(group_value, context='SymmetricContraction')
     group = _resolve_cue_group(cueq_config) if cueq_config else None
-    if cueq_config is not None and use_cue:
-        if cueq_config.layout_str not in {'mul_ir', 'ir_mul'}:
-            raise ValueError(
-                f"Unsupported cuequivariance layout '{cueq_config.layout_str}'."
-            )
+    if equivariance_config is not None and equivariance_config.layout not in {
+        'mul_ir',
+        'ir_mul',
+    }:
+        raise ValueError(
+            f"Unsupported equivariance layout '{equivariance_config.layout}'."
+        )
 
-    input_layout = 'mul_ir'
-    if use_cue:
-        # cuet.SymmetricContraction expects ir_mul inputs regardless of output layout.
-        input_layout = 'ir_mul'
+    input_layout = (
+        equivariance_config.layout
+        if equivariance_config is not None
+        else 'mul_ir'
+    )
 
     sc_kwargs = dict(
         correlation=correlation,
@@ -260,9 +463,15 @@ class TransposeIrrepsLayoutWrapper:
         irreps: Irreps,
         source: str,
         target: str,
-        cueq_config: CuEquivarianceConfig | None = None,
+        equivariance_config: EquivarianceConfig | None = None,
     ):
-        if cueq_config is None or not cueq_config.enabled:
+        # These boundary adapters are needed only while the model-wide
+        # representation is ir_mul.  A mul_ir model already matches the
+        # canonical layout consumed and produced by e3nn nonlinearities.
+        if (
+            equivariance_config is None
+            or equivariance_config.layout != 'ir_mul'
+        ):
             return None
 
         source = source.lower()

--- a/mace_jax/tools/arg_parser.py
+++ b/mace_jax/tools/arg_parser.py
@@ -97,16 +97,65 @@ def build_cli_arg_parser() -> argparse.ArgumentParser:
         help='Disable cueq conv_fusion.',
     )
     parser.add_argument(
+        '--equivariance-layout',
+        choices=['mul_ir', 'ir_mul'],
+        default=None,
+        help='Select the model-wide equivariant representation layout.',
+    )
+    parser.add_argument(
         '--cueq-layout',
         choices=['mul_ir', 'ir_mul'],
         default=None,
-        help='Select cueq layout (mul_ir or ir_mul).',
+        help='Deprecated alias for --equivariance-layout.',
     )
     parser.add_argument(
         '--cueq-group',
         choices=['O3', 'O3_e3nn'],
         default=None,
         help='Select cueq group (O3 or O3_e3nn).',
+    )
+    parser.add_argument(
+        '--enable-openeq',
+        '--enable_openeq',
+        action='store_true',
+        help='Enable OpenEquivariance fused channel-wise convolution.',
+    )
+    parser.add_argument(
+        '--openeq-optimize-all',
+        dest='openeq_optimize_all',
+        action='store_true',
+        default=None,
+        help='Enable all currently supported OpenEquivariance operations.',
+    )
+    parser.add_argument(
+        '--no-openeq-optimize-all',
+        dest='openeq_optimize_all',
+        action='store_false',
+        help='Disable all OpenEquivariance operations.',
+    )
+    parser.add_argument(
+        '--openeq-conv-fusion',
+        dest='openeq_conv_fusion',
+        action='store_true',
+        default=None,
+        help='Enable OpenEquivariance convolution fusion.',
+    )
+    parser.add_argument(
+        '--no-openeq-conv-fusion',
+        dest='openeq_conv_fusion',
+        action='store_false',
+        help='Disable OpenEquivariance convolution fusion.',
+    )
+    parser.add_argument(
+        '--openeq-layout',
+        choices=['mul_ir', 'ir_mul'],
+        default=None,
+        help='Deprecated alias for --equivariance-layout.',
+    )
+    parser.add_argument(
+        '--openeq-group',
+        default=None,
+        help="OpenEquivariance group (v1 requires 'O3_e3nn').",
     )
     parser.add_argument(
         '--distributed',

--- a/mace_jax/tools/gin_model.py
+++ b/mace_jax/tools/gin_model.py
@@ -21,7 +21,12 @@ from flax import nnx
 
 from mace_jax import data, modules, tools
 from mace_jax.modules.blocks import RealAgnosticResidualInteractionBlock
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig,
+    EquivarianceConfig,
+    OpenEquivarianceConfig,
+    resolve_equivariance_config,
+)
 from mace_jax.nnx_config import ConfigVar
 from mace_jax.nnx_utils import state_to_pure_dict
 from mace_jax.tools.dtype import default_dtype
@@ -37,21 +42,23 @@ gin.register('identity')(lambda x: x)
 gin.register('std_scaling')(tools.compute_mean_std_atomic_inter_energy)
 gin.register('rms_forces_scaling')(tools.compute_mean_rms_energy_forces)
 gin.external_configurable(CuEquivarianceConfig)
+gin.external_configurable(EquivarianceConfig)
+gin.external_configurable(OpenEquivarianceConfig)
 for _cls in modules.interaction_classes.values():
     gin.external_configurable(_cls, module='mace_jax.modules')
 gin.external_configurable(modules.UniversalLoss, module='mace_jax.modules')
 
 
-def _resolve_cueq_config(cueq_config):
-    if cueq_config is None:
-        return None
-    if isinstance(cueq_config, CuEquivarianceConfig):
-        return cueq_config
-    if isinstance(cueq_config, dict):
-        return CuEquivarianceConfig(**cueq_config)
+def _resolve_equivariance_config(equivariance_config, cueq_config=None):
+    if callable(equivariance_config):
+        equivariance_config = equivariance_config()
     if callable(cueq_config):
-        return cueq_config()
-    return cueq_config
+        cueq_config = cueq_config()
+    if equivariance_config is None and cueq_config is None:
+        return None
+    return resolve_equivariance_config(
+        equivariance_config, cueq_config=cueq_config
+    )
 
 
 def _stringify_callable(value) -> str | None:
@@ -100,7 +107,7 @@ def _merge_state_dicts(base: dict | None, updates: dict | None) -> dict | None:
 
 def _export_model_config(mace_module: modules.MACE) -> dict:
     """Build a config dict compatible with tools.model_builder._build_jax_model."""
-    cueq_config = getattr(mace_module, 'cueq_config', None)
+    equivariance_config = getattr(mace_module, 'equivariance_config', None)
     config = {
         'r_max': float(mace_module.r_max),
         'num_bessel': int(mace_module.num_bessel),
@@ -127,6 +134,9 @@ def _export_model_config(mace_module: modules.MACE) -> dict:
         ),
         'use_so3': bool(getattr(mace_module, 'use_so3', False)),
         'use_reduced_cg': bool(getattr(mace_module, 'use_reduced_cg', True)),
+        'use_edge_irreps_first': bool(
+            getattr(mace_module, 'use_edge_irreps_first', False)
+        ),
         'use_agnostic_product': bool(
             getattr(mace_module, 'use_agnostic_product', False)
         ),
@@ -153,8 +163,11 @@ def _export_model_config(mace_module: modules.MACE) -> dict:
         config['normalize2mom_consts'] = {
             str(k): float(v) for k, v in normalize2mom_consts.items()
         }
+    cueq_config = getattr(equivariance_config, 'cueq_config', None)
     if cueq_config is not None and getattr(cueq_config, 'conv_fusion', False):
         config['cue_conv_fusion'] = True
+    if equivariance_config is not None:
+        config['equivariance_config'] = equivariance_config.to_dict()
     return config
 
 
@@ -340,6 +353,7 @@ def model(
     torch_checkpoint: str | None = None,
     torch_head: str | None = None,
     torch_param_dtype: str | None = None,
+    equivariance_config=None,
     cueq_config=None,
     **kwargs,
 ):
@@ -370,7 +384,8 @@ def model(
         torch_checkpoint: Optional Torch checkpoint path to convert and wrap.
         torch_head: Optional head name to select from Torch multi-head models.
         torch_param_dtype: Optional dtype override ('float32' or 'float64') for Torch params.
-        cueq_config: Optional CuEquivarianceConfig to enable cueq acceleration paths.
+        equivariance_config: Backend-neutral equivariance acceleration configuration.
+        cueq_config: Deprecated alias for a CuEquivarianceConfig.
         **kwargs: Remaining MACE module constructor arguments.
 
     Returns:
@@ -660,9 +675,11 @@ def model(
             'learnable_atomic_energies is not supported by the Flax-based gin model.'
         )
 
-    cueq_config = _resolve_cueq_config(cueq_config)
-    if cueq_config is not None:
-        kwargs['cueq_config'] = cueq_config
+    equivariance_config = _resolve_equivariance_config(
+        equivariance_config, cueq_config
+    )
+    if equivariance_config is not None:
+        kwargs['equivariance_config'] = equivariance_config
 
     kwargs.update(
         dict(

--- a/mace_jax/tools/model_builder.py
+++ b/mace_jax/tools/model_builder.py
@@ -13,7 +13,11 @@ from mace_jax.adapters.nnx import resolve_gate_callable
 from mace_jax.data.utils import Configuration, graph_from_configuration
 from mace_jax.modules import interaction_classes, readout_classes
 from mace_jax.modules.models import MACE, ScaleShiftMACE
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig,
+    EquivarianceConfig,
+    resolve_equivariance_config,
+)
 from mace_jax.tools.gin_model import _graph_to_data  # type: ignore[attr-defined]
 
 
@@ -226,6 +230,7 @@ def _prepare_template_data(config: dict[str, Any]) -> dict[str, jnp.ndarray]:
 def _build_jax_model(
     config: dict[str, Any],
     *,
+    equivariance_config: EquivarianceConfig | dict[str, object] | None = None,
     cueq_config: CuEquivarianceConfig | None = None,
     rngs: nnx.Rngs | None = None,
 ):
@@ -244,15 +249,28 @@ def _build_jax_model(
             except Exception:
                 collapse_hidden_irreps = None
 
-    cue_config_obj: CuEquivarianceConfig | None = None
-    if cueq_config is not None:
-        cue_config_obj = cueq_config
+    config_equivariance = config.get('equivariance_config')
+    if equivariance_config is not None and config_equivariance is not None:
+        raise ValueError(
+            'equivariance_config was supplied both as an argument and in config.'
+        )
+    if equivariance_config is None:
+        equivariance_config = config_equivariance
+    if equivariance_config is not None:
+        equivariance_config = resolve_equivariance_config(equivariance_config)
+    elif cueq_config is not None:
+        equivariance_config = resolve_equivariance_config(cueq_config=cueq_config)
+    elif config.get('cueq_config') is not None:
+        equivariance_config = resolve_equivariance_config(
+            cueq_config=config['cueq_config']
+        )
     elif config.get('cue_conv_fusion'):
-        cue_config_obj = CuEquivarianceConfig(
-            enabled=False,
-            optimize_channelwise=True,
-            conv_fusion=bool(config['cue_conv_fusion']),
-            layout='mul_ir',
+        equivariance_config = EquivarianceConfig(
+            cueq_config=CuEquivarianceConfig(
+                enabled=False,
+                optimize_channelwise=True,
+                conv_fusion=bool(config['cue_conv_fusion']),
+            )
         )
 
     config, atomic_numbers, atomic_energies = _normalize_atomic_config(
@@ -282,6 +300,7 @@ def _build_jax_model(
         embedding_specs=config.get('embedding_specs'),
         use_so3=config.get('use_so3', False),
         use_reduced_cg=config.get('use_reduced_cg', True),
+        use_edge_irreps_first=config.get('use_edge_irreps_first', False),
         use_agnostic_product=config.get('use_agnostic_product', False),
         use_last_readout_only=config.get('use_last_readout_only', False),
         use_embedding_readout=config.get('use_embedding_readout', False),
@@ -290,7 +309,8 @@ def _build_jax_model(
         ),
         readout_cls=_readout(config.get('readout_cls', None)),
         gate=resolve_gate_callable(config.get('gate', None)),
-        cueq_config=cue_config_obj,
+        heads=config.get('heads'),
+        equivariance_config=equivariance_config,
     )
 
     if config.get('normalize2mom_consts') is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ classifiers =
     Programming Language :: Python :: 3.12
 
 [options]
-packages = find:
+packages = find_namespace:
 python_requires = >=3.10
 install_requires =
     chex
@@ -34,6 +34,9 @@ install_requires =
     pyyaml
 
 [options.extras_require]
+openeq-jax =
+    openequivariance[jax]==0.6.8
+    openequivariance_extjax==0.6.8
 torch-cuda12 =
     torch
     cuequivariance-torch>=0.10,<0.11

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -63,7 +63,10 @@ from mace_jax.modules.blocks import (
 from mace_jax.modules.blocks import (
     RealAgnosticResidualNonLinearInteractionBlock as RealAgnosticResidualNonLinearInteractionBlockJAX,
 )
-from mace_jax.modules.wrapper_ops import CuEquivarianceConfig as CuEquivarianceConfigJAX
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig as CuEquivarianceConfigJAX,
+)
+from mace_jax.modules.wrapper_ops import EquivarianceConfig
 from mace_jax.tools.device import configure_torch_runtime
 
 
@@ -377,7 +380,9 @@ class TestEquivariantProductBasisBlock:
             use_sc=use_sc,
             num_elements=num_elements,
             use_reduced_cg=True,
-            cueq_config=CuEquivarianceConfigJAX(**cue_config_kwargs),
+            equivariance_config=EquivarianceConfig(
+                cueq_config=CuEquivarianceConfigJAX(**cue_config_kwargs)
+            ),
             rngs=nnx.Rngs(42),
         )
         torch_model = torch_model.to('cpu')
@@ -513,7 +518,7 @@ class TestRealAgnosticBlocks:
             target_irreps=irreps,
             hidden_irreps=irreps,
             avg_num_neighbors=3.0,
-            cueq_config=cue_config_jax,
+            equivariance_config=EquivarianceConfig(cueq_config=cue_config_jax),
             rngs=nnx.Rngs(42),
         )
         module, _ = init_from_torch(module, torch_module)

--- a/tests/test_equivariance_config.py
+++ b/tests/test_equivariance_config.py
@@ -1,0 +1,121 @@
+import gin
+import pytest
+
+from mace_jax.cli import mace_jax_train as train_cli
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig,
+    EquivarianceConfig,
+    OpenEquivarianceConfig,
+    resolve_equivariance_config,
+    TransposeIrrepsLayoutWrapper,
+)
+from e3nn_jax import Irreps
+
+
+def test_equivariance_config_canonical_round_trip():
+    config = EquivarianceConfig(
+        layout='ir_mul',
+        cueq_config=CuEquivarianceConfig(optimize_fctp=True),
+        openeq_config=OpenEquivarianceConfig(optimize_channelwise=True),
+    )
+
+    payload = config.to_dict()
+
+    assert EquivarianceConfig(**payload).to_dict() == payload
+    assert payload == {
+        'layout': 'ir_mul',
+        'cueq_config': config.cueq_config.to_dict(),
+        'openeq_config': config.openeq_config.to_dict(),
+    }
+    assert 'layout' not in payload['cueq_config']
+    assert 'layout' not in payload['openeq_config']
+
+
+def test_legacy_nested_cueq_config_is_migrated():
+    legacy = {
+        'layout': 'ir_mul',
+        'layout_str': 'ir_mul',
+        'enabled': False,
+        'conv_fusion': True,
+        'openeq_config': {
+            'enabled': True,
+            'optimize_all': True,
+            'conv_fusion': False,
+        },
+    }
+
+    with pytest.deprecated_call(match='cueq_config is deprecated'):
+        config = resolve_equivariance_config(cueq_config=legacy)
+
+    assert config.layout == 'ir_mul'
+    assert config.cueq_config.conv_fusion
+    assert config.openeq_config.enabled
+
+
+def test_old_and_new_model_configs_are_mutually_exclusive():
+    with pytest.raises(ValueError, match='Specify only equivariance_config'):
+        resolve_equivariance_config(
+            EquivarianceConfig(), cueq_config=CuEquivarianceConfig()
+        )
+
+
+def test_invalid_and_conflicting_layouts_are_rejected():
+    with pytest.raises(ValueError, match='layout must be'):
+        EquivarianceConfig(layout='invalid')
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError, match='conflicting layout'):
+            resolve_equivariance_config(
+                cueq_config={'layout': 'mul_ir', 'layout_str': 'ir_mul'}
+            )
+
+
+def test_cli_binds_neutral_config_and_deprecated_alias():
+    gin.clear_config()
+    args, _ = train_cli.parse_args(
+        ['--enable-openeq', '--equivariance-layout', 'ir_mul']
+    )
+    train_cli.apply_cli_overrides(args)
+    config = gin.query_parameter(
+        'mace_jax.tools.gin_model.model.equivariance_config'
+    )
+    assert isinstance(config, EquivarianceConfig)
+    assert config.layout == 'ir_mul'
+    assert config.openeq_config.enabled
+    gin.clear_config()
+
+    args, _ = train_cli.parse_args(['--cueq-layout', 'ir_mul'])
+    with pytest.deprecated_call(match='--cueq-layout'):
+        train_cli.apply_cli_overrides(args)
+    config = gin.query_parameter(
+        'mace_jax.tools.gin_model.model.equivariance_config'
+    )
+    assert config.layout == 'ir_mul'
+    gin.clear_config()
+
+
+def test_cli_rejects_conflicting_backend_layout_aliases():
+    gin.clear_config()
+    args, _ = train_cli.parse_args(
+        ['--cueq-layout', 'mul_ir', '--openeq-layout', 'ir_mul']
+    )
+    with pytest.raises(ValueError, match='Conflicting equivariance layouts'):
+        train_cli.apply_cli_overrides(args)
+    gin.clear_config()
+
+
+def test_mul_ir_config_does_not_insert_nonlinearity_transposes():
+    transpose = TransposeIrrepsLayoutWrapper(
+        Irreps('2x1o'),
+        source='ir_mul',
+        target='mul_ir',
+        equivariance_config=EquivarianceConfig(layout='mul_ir'),
+    )
+    assert transpose is None
+
+    transpose = TransposeIrrepsLayoutWrapper(
+        Irreps('2x1o'),
+        source='ir_mul',
+        target='mul_ir',
+        equivariance_config=EquivarianceConfig(layout='ir_mul'),
+    )
+    assert transpose is not None

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -69,3 +69,60 @@ class TestGate:
             rtol=1e-5,
             atol=1e-6,
         )
+
+    def test_forward_matches_e3nn_with_repeated_even_gate_irreps(self, monkeypatch):
+        """Mirror Torch Gate behavior when repeated 0e gates simplify together."""
+
+        if not hasattr(IrrepsArray, 'from_array'):
+            monkeypatch.setattr(
+                IrrepsArray,
+                'from_array',
+                staticmethod(lambda irreps, array: IrrepsArray(irreps, array)),
+                raising=False,
+            )
+
+        irreps_scalars = '1x0e'
+        irreps_gates = '1x0e + 1x0e + 1x0e'
+        irreps_gated = '1x1o + 1x2e + 1x3o'
+
+        act_scalars = [None] * len(Irreps(irreps_scalars))
+        act_gates = [None] * len(Irreps(irreps_gates))
+
+        gate_torch = GateTorch(
+            o3.Irreps(irreps_scalars),
+            act_scalars,
+            o3.Irreps(irreps_gates),
+            act_gates,
+            o3.Irreps(irreps_gated),
+        )
+
+        rng = np.random.default_rng(1)
+        features_np = rng.standard_normal((3, gate_torch.irreps_in.dim))
+        features_jax = jnp.array(features_np)
+        features_torch = torch.tensor(features_np)
+
+        with torch.no_grad():
+            out_torch = gate_torch(features_torch).cpu().numpy()
+
+        gate_flax = GateJAX(
+            irreps_scalars=Irreps(irreps_scalars),
+            act_scalars=act_scalars,
+            irreps_gates=Irreps(irreps_gates),
+            act_gates=act_gates,
+            irreps_gated=Irreps(irreps_gated),
+        )
+
+        graphdef, state = nnx.split(gate_flax)
+        variables = state_to_pure_dict(state)
+        variables = GateJAX.import_from_torch(gate_torch, variables)
+        out_jax, _ = graphdef.apply(variables)(features_jax)
+        out_jax_array = np.asarray(
+            out_jax.array if hasattr(out_jax, 'array') else out_jax
+        )
+
+        np.testing.assert_allclose(
+            out_jax_array,
+            out_torch,
+            rtol=1e-5,
+            atol=1e-6,
+        )

--- a/tests/test_import_torch_weights.py
+++ b/tests/test_import_torch_weights.py
@@ -8,6 +8,7 @@ from flax import nnx
 
 from mace_jax.cli import mace_jax_from_torch as jax_from_torch
 from mace_jax.nnx_utils import state_to_pure_dict
+from mace_jax.tools import model_builder
 
 
 def _patch_common(monkeypatch, jax_model):
@@ -70,3 +71,60 @@ def test_convert_model_success(monkeypatch):
     assert template == {'dummy': 1}
     params = state_to_pure_dict(state)
     assert jnp.array_equal(params['w'], jnp.array([42.0], dtype=jnp.float32))
+
+
+def test_build_jax_model_forwards_mh1_specific_config(monkeypatch):
+    captured = {}
+
+    class _SentinelModel:
+        pass
+
+    def _fake_scaleshiftmace(*, rngs, **kwargs):
+        del rngs
+        captured.update(kwargs)
+        return _SentinelModel()
+
+    monkeypatch.setattr(model_builder, 'ScaleShiftMACE', _fake_scaleshiftmace)
+
+    config = {
+        'r_max': 5.0,
+        'num_bessel': 8,
+        'num_polynomial_cutoff': 5,
+        'max_ell': 3,
+        'interaction_cls': 'RealAgnosticResidualNonLinearInteractionBlock',
+        'interaction_cls_first': 'RealAgnosticResidualNonLinearInteractionBlock',
+        'num_interactions': 2,
+        'hidden_irreps': '512x0e + 512x1o',
+        'MLP_irreps': '16x0e',
+        'atomic_numbers': [1, 6],
+        'atomic_energies': [0.0, 0.0],
+        'avg_num_neighbors': 12.0,
+        'correlation': 3,
+        'radial_type': 'bessel',
+        'distance_transform': 'Agnesi',
+        'use_so3': False,
+        'use_reduced_cg': False,
+        'use_edge_irreps_first': True,
+        'use_agnostic_product': True,
+        'use_last_readout_only': False,
+        'use_embedding_readout': False,
+        'edge_irreps': '128x0e + 128x1o',
+        'readout_cls': 'NonLinearReadoutBlock',
+        'gate': 'silu',
+        'heads': [
+            'matpes_r2scan',
+            'mp_pbe_refit_add',
+            'spice_wB97M',
+            'oc20_usemppbe',
+            'omol',
+            'omat_pbe',
+        ],
+        'atomic_inter_scale': 1.0,
+        'atomic_inter_shift': 0.0,
+    }
+
+    model = model_builder._build_jax_model(config)
+
+    assert isinstance(model, _SentinelModel)
+    assert captured['use_edge_irreps_first'] is True
+    assert captured['heads'] == tuple(config['heads']) or captured['heads'] == config['heads']

--- a/tests/test_irreps_tools.py
+++ b/tests/test_irreps_tools.py
@@ -5,7 +5,7 @@ from e3nn_jax import Irreps, IrrepsArray
 from mace.modules.irreps_tools import CuEquivarianceConfig as TorchCuEquivarianceConfig
 from mace.modules.irreps_tools import reshape_irreps as TorchReshapeIrreps
 
-from mace_jax.modules.irreps_tools import CuEquivarianceConfig, reshape_irreps
+from mace_jax.modules.irreps_tools import EquivarianceConfig, reshape_irreps
 
 
 def _random_flat(batch: int, irreps: Irreps, rng: np.random.Generator) -> np.ndarray:
@@ -45,8 +45,8 @@ class TestReshapeIrreps:
         torch_out = torch_module(torch.tensor(tensor_np, dtype=torch.float32))
         torch_np = torch_out.detach().cpu().numpy()
 
-        jax_cfg = CuEquivarianceConfig(layout_str='ir_mul')
-        jax_module = reshape_irreps(irreps, cueq_config=jax_cfg)
+        jax_cfg = EquivarianceConfig(layout='ir_mul')
+        jax_module = reshape_irreps(irreps, equivariance_config=jax_cfg)
         jax_np = np.asarray(jax_module(tensor_np))
 
         np.testing.assert_allclose(jax_np, torch_np, rtol=1e-6, atol=1e-7)

--- a/tests/test_lammps_exchange.py
+++ b/tests/test_lammps_exchange.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from mace_jax.modules import utils as models_utils
+from mace_jax.modules import models, utils as models_utils
 from mace_jax.tools import lammps_exchange
 
 
@@ -16,6 +16,15 @@ class _DummyLAMMPS:
     def forward_exchange(self, src, dst, vec_len):
         self.calls += 1
         np.copyto(dst, src[::-1])
+
+
+class _DummyComm:
+    def __init__(self):
+        self.calls = 0
+
+    def gather(self, features):
+        self.calls += 1
+        return features + 1
 
 
 def test_forward_exchange_requires_lammps_interface():
@@ -40,6 +49,21 @@ def test_apply_lammps_exchange_forwards_to_lammps():
     expected = np.asarray([[3.0, 4.0], [1.0, 2.0]])
     np.testing.assert_allclose(np.asarray(result), expected)
     assert dummy.calls == 1
+
+
+def test_apply_comm_exchange_gathers_features():
+    feats = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.float32)
+    comm = _DummyComm()
+
+    result = models._apply_comm_exchange(feats, comm)
+
+    np.testing.assert_allclose(np.asarray(result), np.asarray(feats + 1))
+    assert comm.calls == 1
+
+
+def test_apply_comm_exchange_requires_gather_interface():
+    with pytest.raises(AttributeError, match='must implement gather'):
+        models._apply_comm_exchange(jnp.ones((2, 2)), object())
 
 
 def test_prepare_graph_carries_lammps_metadata():

--- a/tests/test_openequivariance_adapters.py
+++ b/tests/test_openequivariance_adapters.py
@@ -1,0 +1,97 @@
+import sys
+import types
+
+import jax.numpy as jnp
+import numpy as np
+from e3nn_jax import Irreps
+from flax import nnx
+
+from mace_jax.adapters.e3nn.nn._fc import FullyConnectedNet
+from mace_jax.adapters.openequivariance import (
+    FullyConnectedTensorProduct,
+    TensorProduct,
+)
+
+
+def _install_fake_backend(monkeypatch):
+    package = types.ModuleType('openequivariance')
+    package.__path__ = []
+    jax_module = types.ModuleType('openequivariance.jax')
+
+    class Problem:
+        weight_numel = 2
+
+        def __init__(self, *args, **kwargs):
+            self.shared_weights = kwargs['shared_weights']
+            self.instructions = args[3]
+
+    class Operator:
+        def __init__(self, problem, **kwargs):
+            self.problem = problem
+
+        def reorder_weights_from_e3nn(self, weights, has_batch_dim=True):
+            return weights[..., ::-1]
+
+        def forward(self, x1, x2, weights):
+            return x1 * x2 * weights
+
+    class Conv(Operator):
+        def forward(self, x1, x2, weights, rows, cols):
+            values = x1[cols] * x2 * weights
+            return jnp.zeros_like(x1).at[rows].add(values)
+
+    package.Irreps = lambda value: value
+    package.TPProblem = Problem
+    package.jax = jax_module
+    jax_module.TensorProduct = Operator
+    jax_module.TensorProductConv = Conv
+    monkeypatch.setitem(sys.modules, 'openequivariance', package)
+    monkeypatch.setitem(sys.modules, 'openequivariance.jax', jax_module)
+
+
+def test_standalone_tp_reorders_canonical_shared_weights(monkeypatch):
+    _install_fake_backend(monkeypatch)
+    tp = TensorProduct(
+        Irreps('2x0e'),
+        Irreps('2x0e'),
+        Irreps('2x0e'),
+        instructions=[(0, 0, 0, 'uvw', True)],
+        shared_weights=True,
+        conv_fusion=False,
+        rngs=nnx.Rngs(0),
+    )
+    dtype = tp.dtype
+    actual = tp(
+        jnp.ones((3, 2), dtype=dtype),
+        jnp.ones((3, 2), dtype=dtype),
+        jnp.asarray([2.0, 5.0], dtype=dtype),
+    )
+    np.testing.assert_allclose(actual, np.tile([5.0, 2.0], (3, 1)))
+
+
+def test_fctp_builds_weighted_uvw_paths_and_restores(monkeypatch):
+    _install_fake_backend(monkeypatch)
+    fctp = FullyConnectedTensorProduct(
+        Irreps('2x0e'),
+        Irreps('2x0e'),
+        Irreps('2x0e'),
+        internal_weights=True,
+        rngs=nnx.Rngs(0),
+    )
+    assert all(path[3:5] == ('uvw', True) for path in fctp.instructions)
+    graphdef, state = nnx.split(fctp)
+    restored = nnx.merge(graphdef, state)
+    assert restored(jnp.empty((0, 2)), jnp.empty((0, 2))).shape == (0, 2)
+
+
+def test_projection_reorders_parameter_columns_not_batch_output():
+    network = FullyConnectedNet(
+        [3, 2], output_permutation=(1, 0), rngs=nnx.Rngs(0)
+    )
+    canonical_weight = np.asarray(network.layers[0].weight)
+    x = jnp.arange(12.0).reshape(4, 3)
+    actual = network(x)
+    scale = np.sqrt(3.0)
+    expected = np.asarray(x) @ canonical_weight[:, ::-1] / scale
+    np.testing.assert_allclose(actual, expected, rtol=1e-6)
+    np.testing.assert_array_equal(np.asarray(network.layers[0].weight), canonical_weight)

--- a/tests/test_openequivariance_config.py
+++ b/tests/test_openequivariance_config.py
@@ -1,0 +1,210 @@
+import sys
+import types
+
+import gin
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from e3nn_jax import Irreps
+from flax import nnx
+
+from mace_jax.adapters.openequivariance import TensorProduct as OpenEqTensorProduct
+from mace_jax.cli import mace_jax_train as train_cli
+from mace_jax.modules.wrapper_ops import (
+    CuEquivarianceConfig,
+    EquivarianceConfig,
+    FullyConnectedTensorProduct,
+    OpenEquivarianceConfig,
+    TensorProduct,
+)
+
+
+def _enabled(**kwargs):
+    return OpenEquivarianceConfig(
+        enabled=True, optimize_all=True, conv_fusion=True, **kwargs
+    )
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'match'),
+    [
+        ({'group': 'O3'}, "group='O3_e3nn'"),
+        ({'optimize_linear': True}, 'optimize_linear'),
+        ({'optimize_symmetric': True}, 'optimize_symmetric'),
+        ({'optimize_fctp': True}, 'not safe for general FCTP'),
+    ],
+)
+def test_openeq_rejects_unsupported_options(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        _enabled(**kwargs)
+
+
+def test_openeq_rejects_fctp_from_serialized_config():
+    with pytest.raises(ValueError, match='not safe for general FCTP'):
+        EquivarianceConfig(openeq_config={'enabled': True, 'optimize_fctp': True})
+
+
+def test_openeq_adapter_rejects_standalone_tensor_products():
+    with pytest.raises(ValueError, match='Standalone OpenEquivariance'):
+        OpenEqTensorProduct(
+            Irreps('1x0e'),
+            Irreps('1x0e'),
+            Irreps('1x0e'),
+            instructions=[(0, 0, 0, 'uvw', True)],
+            shared_weights=True,
+            internal_weights=False,
+            conv_fusion=False,
+            rngs=nnx.Rngs(0),
+        )
+
+
+def test_optimize_all_does_not_select_openeq_fctp():
+    module = FullyConnectedTensorProduct(
+        Irreps('1x0e'),
+        Irreps('1x0e'),
+        Irreps('1x0e'),
+        shared_weights=True,
+        internal_weights=True,
+        equivariance_config=EquivarianceConfig(openeq_config=_enabled()),
+        rngs=nnx.Rngs(0),
+    )
+    assert not type(module).__module__.startswith(
+        'mace_jax.adapters.openequivariance'
+    )
+
+
+def test_openeq_selects_only_fused_channelwise_configuration():
+    assert not OpenEquivarianceConfig(enabled=True).channelwise_fusion
+    assert not OpenEquivarianceConfig(
+        enabled=True, optimize_all=True
+    ).channelwise_fusion
+    assert _enabled().channelwise_fusion
+
+
+def test_cueq_rejects_same_kernel_conflict():
+    with pytest.raises(ValueError, match='cannot both be selected'):
+        EquivarianceConfig(
+            cueq_config=CuEquivarianceConfig(
+                enabled=True,
+                optimize_channelwise=True,
+            ),
+            openeq_config=_enabled(),
+        )
+
+
+def test_config_round_trip_is_canonical_and_legacy_is_preserved():
+    config = EquivarianceConfig(openeq_config=_enabled())
+    payload = config.to_dict()
+    restored = EquivarianceConfig(**payload)
+    assert restored.to_dict() == payload
+    assert payload['layout'] == 'mul_ir'
+    assert payload['cueq_config'] is None
+    assert payload['openeq_config']['group'] == 'O3_e3nn'
+
+
+def test_cli_binds_openeq_config():
+    gin.clear_config()
+    args, _ = train_cli.parse_args(['--enable-openeq'])
+    train_cli.apply_cli_overrides(args)
+    config = gin.query_parameter(
+        'mace_jax.tools.gin_model.model.equivariance_config'
+    )
+    assert isinstance(config, EquivarianceConfig)
+    assert config.openeq_config.enabled
+    assert config.openeq_config.optimize_all
+    assert config.openeq_config.conv_fusion
+    gin.clear_config()
+
+
+def test_openeq_import_is_lazy_and_missing_dependency_is_actionable(monkeypatch):
+    for name in list(sys.modules):
+        if name.startswith('openequivariance'):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    config = EquivarianceConfig(openeq_config=_enabled())
+    assert 'openequivariance' not in sys.modules
+    import builtins
+
+    real_import = builtins.__import__
+
+    def missing_openeq(name, *args, **kwargs):
+        if name.startswith('openequivariance'):
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', missing_openeq)
+    with pytest.raises(RuntimeError, match=r'openequivariance\[jax\]==0.6.8'):
+        TensorProduct(
+            Irreps('1x0e'),
+            Irreps('1x0e'),
+            Irreps('1x0e'),
+            instructions=[(0, 0, 0, 'uvu', True)],
+            shared_weights=False,
+            internal_weights=False,
+            equivariance_config=config,
+            rngs=nnx.Rngs(0),
+        )
+
+
+def test_adapter_uses_receiver_rows_sender_cols_and_permuted_weights(monkeypatch):
+    package = types.ModuleType('openequivariance')
+    package.__path__ = []
+    jax_module = types.ModuleType('openequivariance.jax')
+
+    class FakeProblem:
+        weight_numel = 1
+
+        def __init__(self, *args, **kwargs):
+            assert kwargs['irrep_normalization'] == 'component'
+            assert kwargs['path_normalization'] == 'element'
+            assert kwargs['layout'] == 'mul_ir'
+
+    class FakeConv:
+        def __init__(self, problem, **kwargs):
+            assert kwargs == {'deterministic': False, 'requires_jvp': True}
+
+        def reorder_weights_from_e3nn(self, weights, has_batch_dim):
+            assert has_batch_dim
+            return weights
+
+        def forward(self, nodes, edges, weights, rows, cols):
+            assert rows.dtype == jnp.int32
+            assert cols.dtype == jnp.int32
+            values = nodes[cols, :1] * edges[:, :1] * weights[:, :1]
+            return jnp.zeros((nodes.shape[0], 1), nodes.dtype).at[rows].add(values)
+
+    package.Irreps = lambda value: value
+    package.TPProblem = FakeProblem
+    package.jax = jax_module
+    jax_module.TensorProductConv = FakeConv
+    monkeypatch.setitem(sys.modules, 'openequivariance', package)
+    monkeypatch.setitem(sys.modules, 'openequivariance.jax', jax_module)
+
+    module = TensorProduct(
+        Irreps('1x0e'),
+        Irreps('1x0e'),
+        Irreps('1x0e'),
+        instructions=[(0, 0, 0, 'uvu', True)],
+        shared_weights=False,
+        internal_weights=False,
+        equivariance_config=EquivarianceConfig(openeq_config=_enabled()),
+        rngs=nnx.Rngs(0),
+    )
+    dtype = module.dtype
+    edge_index = jnp.asarray([[2, 0, 2], [1, 1, 0]], dtype=jnp.int64)
+    actual = module(
+        jnp.asarray([[1.0], [2.0], [3.0]], dtype=dtype),
+        jnp.ones((3, 1), dtype=dtype),
+        jnp.ones((3, 1), dtype=dtype),
+        edge_index,
+    )
+    np.testing.assert_allclose(actual, np.asarray([[3.0], [4.0], [0.0]]))
+
+    graphdef, state = nnx.split(module)
+    restored = nnx.merge(graphdef, state)
+    empty = restored(
+        jnp.ones((2, 1), dtype=dtype),
+        jnp.empty((0, 1), dtype=dtype),
+        jnp.empty((0, 1), dtype=dtype),
+        jnp.empty((2, 0), dtype=jnp.int32),
+    )
+    assert empty.shape == (2, 1)


### PR DESCRIPTION
Thanks for maintaining MACE in JAX! We actively use your implementation in our group within our [chemtrain](https://github.com/tummfm/chemtrain) framework. We also support Multi-GPU simulations through LAMMPS (see chemtrain-deploy) and would like to support OpenEquivariance for acceleration. For this, we implemented an integration into MACE-JAX. We also enable support for MACE-MH-1.

### Support for MACE-MH-1

- multi-head metadata is forwarded into the JAX model
- `use_edge_irreps_first` is supported for the first interaction block
- model export/import preserves relevant architecture flags and normalization constants
- the JAX Gate implementation now matches Torch behavior for repeated gate irreps, avoiding incorrect simplification of gate structure

### OpenEquivariance integration
OpenEquivariance is available as an optional backend for fused channel-wise tensor-product convolution in message passing.

**Supported**:

- fused channel-wise convolution
- CUDA atomic aggregation
- inference and force-training derivative paths

Unsupported paths fail explicitly instead of silently falling back, including OpenEquivariance linear layers, symmetric contractions, and general FCTP acceleration.

The previous config for ``cuEquivariance`` is now backend-neutral through `EquivarianceConfig`, with nested `cueq_config` and `openeq_config`. OpenEquivariance can be enabled from Python/Gin/CLI, for example with `--enable-openeq`, `--openeq-optimize-all`, and `--openeq-conv-fusion`. The shared equivariant layout is configured via `--equivariance-layout`.

We tested the integration in our deployed LAMMPS model with the MACE-MH-1 PyTorch model in ASE  on 10 systems from the SPICE test set and achieve numerical accuracy:
<img width="1196" height="563" alt="image" src="https://github.com/user-attachments/assets/5c2c154e-03be-49c0-8913-86a8c36f397b" />